### PR TITLE
Add support to add arbitrary entities to menu

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -171,22 +171,6 @@ export class FrigateCardEditor extends LitElement implements LovelaceCardEditor 
         </div>
         ${options.optional.show
           ? html` <div class="values">
-              <paper-dropdown-menu
-                label=${localize('editor.motion_entity')}
-                @value-changed=${this._valueChanged}
-                .configValue=${'motion_entity'}
-              >
-                <paper-listbox
-                  slot="dropdown-content"
-                  .selected=${binarySensorEntities.indexOf(
-                    this._config?.motion_entity || '',
-                  )}
-                >
-                  ${binarySensorEntities.map((entity) => {
-                    return html` <paper-item>${entity}</paper-item> `;
-                  })}
-                </paper-listbox>
-              </paper-dropdown-menu>
               <paper-input
                 label=${localize('editor.frigate_camera_name')}
                 .value=${this._config?.frigate_camera_name || ''}
@@ -323,17 +307,7 @@ export class FrigateCardEditor extends LitElement implements LovelaceCardEditor 
                   @change=${this._valueChanged}
                 ></ha-switch>
               </ha-formfield>
-              <br />
-              <ha-formfield
-                .label=${localize('editor.show_button') + ': ' + localize('menu.motion')}
-              >
-                <ha-switch
-                  .checked=${this._config?.menu_buttons?.frigate_ui ?? true}
-                  .configValue=${'menu_buttons.motion'}
-                  @change=${this._valueChanged}
-                ></ha-switch>
-              </ha-formfield>
-              <br /> `
+              <br />`
           : ''}
         <div class="option" @click=${this._toggleOption} .option=${'advanced'}>
           <div class="row">

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -18,7 +18,6 @@
     "advanced": "Advanced",
     "advanced_secondary": "Advanced options",
     "camera_entity": "Camera Entity (Required)",
-    "motion_entity": "Motion Entity (Optional)",
     "frigate_camera_name": "Frigate camera name (Optional)",
     "default_view": "Default view (Optional)",
     "frigate_client_id": "Frigate client id (Optional, for >1 Frigate server)",
@@ -38,8 +37,7 @@
     "snapshots": "Snapshots Gallery",
     "clip": "Latest Clip",
     "snapshot": "Latest Snapshot",
-    "frigate_ui": "Frigate User Interface",
-    "motion": "Motion Entity"
+    "frigate_ui": "Frigate User Interface"
   },
   "menu_mode": {
     "hidden-top": "Hidden Top",

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,7 +41,6 @@ export type FrigateMenuMode = typeof FRIGATE_MENU_MODES[number];
 
 export const frigateCardConfigSchema = z.object({
   camera_entity: z.string(),
-  motion_entity: z.string().optional(),
   // No URL validation to allow relative URLs within HA (e.g. addons).
   frigate_url: z.string().optional(),
   frigate_client_id: z.string().optional().default("frigate"),
@@ -68,15 +67,12 @@ export const frigateCardConfigSchema = z.object({
     clips: z.boolean().default(true),
     snapshots: z.boolean().default(true),
     frigate_ui: z.boolean().default(true),
-    motion: z.boolean().default(true),
-  }).default({
-    frigate: true,
-    live: true,
-    clips: true,
-    snapshots: true,
-    frigate_ui: true,
-    motion: true,
   }),
+  entities: z.object({
+    entity: z.string(),
+    show: z.boolean().default(true),
+    icon: z.string().optional(),
+  }).array().optional(),
 
   // Stock lovelace card config.
   type: z.string(),


### PR DESCRIPTION
* Allow arbitrary entities to be added to menu / trigger an update.
* Breaking: No longer treat the motion entity special. It must be configured under `entities` now.
* Closes #27 