### PR TITLE
Show event titles in viewer for reference

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -83,11 +83,6 @@ export const frigateCardConfigSchema = z.object({
 });
 export type FrigateCardConfig = z.infer<typeof frigateCardConfigSchema>;
 
-export interface MediaBeingShown {
-  browseMedia: BrowseMediaSource;
-  resolvedMedia: ResolvedMedia;
-}
-
 export interface MenuButton {
   icon?: string;
   description: string;


### PR DESCRIPTION
 * Also removes `MediaBeingShown` as Frigate no longer gives a way to link to a single event. Link to the events page for the camera instead.