### PR TITLE
Add fullscreen mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A full-featured Frigate Lovelace card:
 * Automatic updating to continually show latest clip / snapshot.
 * Support for filtering events by zone and label.
 * Arbitrary entity access via menu (e.g. motion sensor access).
+* Fullscreen event gallery & media viewing.
 * Full Lovelace editing support.
 * Theme friendly.
 * **Advanced**: Support for [WebRTC](https://github.com/AlexxIT/WebRTC) live viewing by embedding the WebRTC card.
@@ -73,19 +74,28 @@ lovelace:
 | Option           | Default | Description                                         |
 | ------------- | --------------------------------------------- | - |
 | `frigate_camera_name` | The string after the "camera." in the `camera_entity` option (above). | This parameter allows the camera name heuristic to be overriden for cases where the entity name does not cleanly map to the Frigate camera name (e.g. when the Frigate camera name is capitalized, but the entity name is lower case). This camera name is used for communicating with the Frigate backend, e.g. for fetching events. |
-| `live_provider` | `frigate` | Whether `frigate` (the default Frigate camera in Home Assistant which uses an RTMP stream), `frigate-jsmpeg` (JSMPEG stream proxied from the Frigate backend) or `webrtc` should provide the live camera view. See [note below on the required integration version](#jsmpeg-troubleshooting) for `frigate-jsmpeg` to function.|
+| `live_provider` | `frigate` | The means through which the live camera view is displayed. See [Live Provider](#live-provider) below.|
 | `view_default` | `live` | The view to show by default. See [views](#views) below.|
 | `frigate_client_id` | `frigate` | The Frigate client id to use. If this Home Assistant server has multiple Frigate server backends configured, this selects which server should be used. It should be set to the MQTT client id configured for this server, see [Frigate Integration Multiple Instance Support](https://blakeblackshear.github.io/frigate/usage/home-assistant/#multiple-instance-support).|
 | `view_timeout` | | A numbers of seconds of inactivity after which the card will reset to the default configured view. Inactivity is defined as lack of interaction with the Frigate menu.|
 | `frigate_url` | | The URL of the frigate server. If set, this value will be (exclusively) used for a `Frigate UI` menu button. |
 | `autoplay_clip` | `false` | Whether or not to autoplay clips in the 'clip' [view](#views). Clips manually chosen in the clips gallery will still autoplay.|
 
+
+#### Live Provider
+
+|Live Provider|Latency|Frame Rate|Installation|Description|
+| -- | -- | -- | -- | -- |
+|`frigate`|High|High|Builtin|Use the built-in Home Assistant camera stream from Frigate (RTMP). The camera doesn't even need to be a Frigate camera! |
+|`frigate-jsmpeg`|Lower|Low|Builtin|Stream the JSMPEG stream from Frigate (proxied via the Frigate integration). See [note below on the required integration version](#jsmpeg-troubleshooting) for this live provider to function.|
+|`webrtc`|Lowest|High|Separate installation required|Uses [WebRTC](https://github.com/AlexxIT/WebRTC) to stream live feed, requires manual extra setup, see [below](#webrtc).|
+
 ### Appearance
 
 | Option           | Default | Description                                         |
 | ------------- | --------------------------------------------- | - |
 | `menu_mode` | `hidden-top` | The menu mode to show by default. See [menu modes](#menu-modes) below.|
-| `menu_buttons.{frigate, live, clips, snapshots, frigate_ui}` | `true` | Whether or not to show these builtin actions in the card menu. |
+| `menu_buttons.{frigate, live, clips, snapshots, frigate_ui, fullscreen}` | `true` | Whether or not to show these builtin actions in the card menu. |
 | `controls.nextprev` | `thumbnails` | When viewing media, what kind of controls to show to move to the previous/next media item. Acceptable values: `thumbnails`, `chevrons`, `none` . |
 | `dimensions.aspect_ratio_mode` | `dynamic` | The aspect ratio mode to use. Acceptable values: `dynamic`, `static`, `unconstrained`. See [aspect ratios](#aspect-ratios) below.|
 | `dimensions.aspect_ratio` | `16:9` | The aspect ratio  to use. Acceptable values: `<W>:<H>` or `<W>/<H>`. See [aspect ratios](#aspect-ratios) below.|

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "dayjs": "^1.10.6",
     "home-assistant-js-websocket": "^5.11.1",
     "lit": "^2.0.0-rc.2",
+    "screenfull": "^5.1.0",
     "zod": "^3.8.2"
   },
   "devDependencies": {

--- a/src/components/gallery.ts
+++ b/src/components/gallery.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { CSSResultGroup, LitElement, TemplateResult, html, unsafeCSS } from 'lit';
-import { customElement, property } from 'lit/decorators';
+import { customElement, property, state } from 'lit/decorators';
 import { until } from 'lit/directives/until.js';
 import { HomeAssistant } from 'custom-card-helpers';
 
@@ -33,6 +33,8 @@ export class FrigateCardGallery extends LitElement {
   protected browseMediaQueryParameters!: BrowseMediaQueryParameters;
 
   protected _resizeObserver: ResizeObserver;
+
+  @state()
   protected _columns = DEFAULT_COLUMNS;
 
   protected _getMediaType(): 'clips' | 'snapshots' {
@@ -53,15 +55,10 @@ export class FrigateCardGallery extends LitElement {
     super.disconnectedCallback();
   }
   protected _resizeHandler(): void {
-    let columns = Math.floor(this.clientWidth / MAX_THUMBNAIL_WIDTH);
-
-    if (columns < DEFAULT_COLUMNS) {
-      columns = DEFAULT_COLUMNS;
-    }
-    if (this._columns != columns) {
-      this._columns = columns;
-      this.requestUpdate();
-    }
+    this._columns = Math.max(
+      DEFAULT_COLUMNS,
+      Math.floor(this.clientWidth / MAX_THUMBNAIL_WIDTH),
+    );
   }
 
   protected render(): TemplateResult | void {
@@ -90,7 +87,8 @@ export class FrigateCardGallery extends LitElement {
     }
 
     const styles = {
-      width: `calc(${100/this._columns}% - 1.2px)`
+      // Controls the number of columns in the gallery (allows for 1px gutter).
+      width: `calc(${100 / this._columns}% - 1.2px)`,
     };
 
     console.info(this.clientWidth);

--- a/src/components/gallery.ts
+++ b/src/components/gallery.ts
@@ -16,6 +16,10 @@ import { localize } from '../localize/localize';
 import { renderMessage, renderErrorMessage, renderProgressIndicator } from './message';
 
 import galleryStyle from '../scss/gallery.scss';
+import { styleMap } from 'lit/directives/style-map.js';
+
+const MAX_THUMBNAIL_WIDTH = 175;
+const DEFAULT_COLUMNS = 5;
 
 @customElement('frigate-card-gallery')
 export class FrigateCardGallery extends LitElement {
@@ -28,8 +32,36 @@ export class FrigateCardGallery extends LitElement {
   @property({ attribute: false })
   protected browseMediaQueryParameters!: BrowseMediaQueryParameters;
 
+  protected _resizeObserver: ResizeObserver;
+  protected _columns = DEFAULT_COLUMNS;
+
   protected _getMediaType(): 'clips' | 'snapshots' {
     return this.view?.view == 'clips' ? 'clips' : 'snapshots';
+  }
+
+  constructor() {
+    super();
+    this._resizeObserver = new ResizeObserver(this._resizeHandler.bind(this));
+  }
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    this._resizeObserver?.observe(this);
+  }
+  disconnectedCallback(): void {
+    this._resizeObserver.disconnect();
+    super.disconnectedCallback();
+  }
+  protected _resizeHandler(): void {
+    let columns = Math.floor(this.clientWidth / MAX_THUMBNAIL_WIDTH);
+
+    if (columns < DEFAULT_COLUMNS) {
+      columns = DEFAULT_COLUMNS;
+    }
+    if (this._columns != columns) {
+      this._columns = columns;
+      this.requestUpdate();
+    }
   }
 
   protected render(): TemplateResult | void {
@@ -57,9 +89,14 @@ export class FrigateCardGallery extends LitElement {
       );
     }
 
+    const styles = {
+      width: `calc(${100/this._columns}% - 1.2px)`
+    };
+
+    console.info(this.clientWidth);
     return html` <ul class="mdc-image-list frigate-card-gallery">
       ${this.view && this.view.previous
-        ? html`<li class="mdc-image-list__item">
+        ? html`<li class="mdc-image-list__item" style="${styleMap(styles)}">
             <div class="mdc-image-list__image-aspect-container">
               <div class="mdc-image-list__image">
                 <ha-card
@@ -79,7 +116,7 @@ export class FrigateCardGallery extends LitElement {
         : ''}
       ${parent.children.map(
         (child, index) =>
-          html` <li class="mdc-image-list__item">
+          html` <li class="mdc-image-list__item" style="${styleMap(styles)}">
             <div class="mdc-image-list__image-aspect-container">
               ${child.can_expand
                 ? html`<div class="mdc-image-list__image">

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -386,6 +386,18 @@ export class FrigateCardEditor extends LitElement implements LovelaceCardEditor 
                   @change=${this._valueChanged}
                 ></ha-switch>
               </ha-formfield>
+              <br />
+              <ha-formfield
+                .label=${localize('editor.show_button') +
+                ': ' +
+                localize('menu.fullscreen')}
+              >
+                <ha-switch
+                  .checked=${this._config?.menu_buttons?.frigate_ui ?? true}
+                  .configValue=${'menu_buttons.fullscreen'}
+                  @change=${this._valueChanged}
+                ></ha-switch>
+              </ha-formfield>
               <br />`
           : ''}
         <div class="option" @click=${this._toggleOption} .option=${'advanced'}>

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -41,7 +41,8 @@
     "snapshots": "Snapshots Gallery",
     "clip": "Latest Clip",
     "snapshot": "Latest Snapshot",
-    "frigate_ui": "Frigate User Interface"
+    "frigate_ui": "Frigate User Interface",
+    "fullscreen": "Fullscreen"
   },
   "control": {
     "nextprev": "Media Next & Previous Controls",
@@ -93,7 +94,6 @@
     "could_not_resolve": "Could not resolve media URL",
     "no_live_camera": "No live camera",
     "invalid_configuration": "Invalid configuration",
-    "missing_webrtc": "WebRTC component not found",
-    "internal": "Internal error"
+    "missing_webrtc": "WebRTC component not found"
   }
 }

--- a/src/patches/ha-hls-player.ts
+++ b/src/patches/ha-hls-player.ts
@@ -31,8 +31,10 @@ customElements.whenDefined("ha-hls-player").then(() => {
           .muted=${this.muted}
           ?playsinline=${this.playsInline}
           ?controls=${this.controls}
-          @loadedmetadata=${(e) => dispatchMediaLoadEvent(this, e)}
-          @loadeddata=${this._elementResized}
+          @loadeddata=${(e) => {
+            this._elementResized();
+            dispatchMediaLoadEvent(this, e);
+          }}
           @pause=${() => dispatchPauseEvent(this)}
           @play=${() => dispatchPlayEvent(this)}
         ></video>

--- a/src/scss/card.scss
+++ b/src/scss/card.scss
@@ -1,5 +1,7 @@
 .container {
   position: relative;
+  overflow: auto;
+  height: 100%;
 }
 
 .frigate-card-contents {
@@ -8,6 +10,11 @@
   overflow: auto;
   -ms-overflow-style: none; /* Hide scrollbar: IE and Edge */
   scrollbar-width: none;    /* Hide scrollbar: Firefox */
+
+  // Vertically align items in case the container is larger than the media (e.g.
+  // fullscreen mode, or forced aspect ratios).
+  display: flex;
+  align-items: center;
 }
 
 /* Hide scrollbar for Chrome, Safari and Opera */
@@ -15,7 +22,7 @@
   display: none;
 }
 
-/* The 'hover' menu mode is styling applied outside of the menu itself */
+/* When forcing aspect ratio absolute positioning is required */
 .frigate-card-contents.absolute {
   position: absolute;
   top: 0px;
@@ -24,7 +31,7 @@
   left: 0px;
 }
 
-/* Support the 'hover' menu mode. */
+/* The 'hover' menu mode is styling applied outside of the menu itself */
 .hover-menu {
   z-index: 1;
   transition: all 0.5s ease;
@@ -50,4 +57,31 @@ ha-card {
 
 ha-card a {
   color: var(--primary-text-color, white);
+}
+
+frigate-card-gallery, frigate-card-viewer, frigate-card-live {
+  width: 100%;
+}
+frigate-card-gallery {
+  height: 100%;
+}
+
+// Browsers will reject invalid whole CSS selectors if one selector is bad, so
+// need to use mixin here instead of just comma-separated selectors.
+//  - Related: https://stackoverflow.com/questions/16982449/why-isnt-it-possible-to-combine-vendor-specific-pseudo-elements-classes-into-on
+@mixin fullscreen-ha-card {
+  // Make the background black, to give it the expected fullscreen feel.
+  background-color: black;
+}
+:host(:fullscreen) ha-card {
+  @include fullscreen-ha-card;
+}
+:host(:-webkit-full-screen) ha-card {
+  @include fullscreen-ha-card;
+}
+:host(:-moz-full-screen) ha-card {
+  @include fullscreen-ha-card;
+}
+:host(:-webkit-full-screen) ha-card {
+  @include fullscreen-ha-card;
 }

--- a/src/scss/card.scss
+++ b/src/scss/card.scss
@@ -72,6 +72,9 @@ frigate-card-gallery {
 @mixin fullscreen-ha-card {
   // Make the background black, to give it the expected fullscreen feel.
   background-color: black;
+
+  // Hide corners on Safari fullscreen.
+  border-radius: 0px;
 }
 :host(:fullscreen) ha-card {
   @include fullscreen-ha-card;

--- a/src/scss/card.scss
+++ b/src/scss/card.scss
@@ -2,19 +2,18 @@
   position: relative;
   overflow: auto;
   height: 100%;
+  width: 100%;
+  margin: auto;
+  display: flex;
+  justify-content: center;
 }
 
 .frigate-card-contents {
   width: 100%;
-  height: 100%;
+  margin: auto;
   overflow: auto;
   -ms-overflow-style: none; /* Hide scrollbar: IE and Edge */
   scrollbar-width: none;    /* Hide scrollbar: Firefox */
-
-  // Vertically align items in case the container is larger than the media (e.g.
-  // fullscreen mode, or forced aspect ratios).
-  display: flex;
-  align-items: center;
 }
 
 /* Hide scrollbar for Chrome, Safari and Opera */
@@ -61,6 +60,7 @@ ha-card a {
 
 frigate-card-gallery, frigate-card-viewer, frigate-card-live {
   width: 100%;
+  display: block;
 }
 frigate-card-gallery {
   height: 100%;

--- a/src/scss/gallery.scss
+++ b/src/scss/gallery.scss
@@ -2,6 +2,8 @@
 @use "@material/image-list";
 
 .frigate-card-gallery {
+  // Note: In fullscreen, number of columns is overwritten in Javascript based
+  // on dimensions.
   @include image-list.standard-columns(5, 1px);
   @include image-list.shape-radius(5px);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,7 +82,7 @@ export const frigateCardConfigSchema = z.object({
       clips: z.boolean().default(true),
       snapshots: z.boolean().default(true),
       frigate_ui: z.boolean().default(true),
-      fullscreen: z.boolean().default(false),
+      fullscreen: z.boolean().default(true),
     })
     .optional(),
   entities: z

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,7 @@ export const frigateCardConfigSchema = z.object({
       clips: z.boolean().default(true),
       snapshots: z.boolean().default(true),
       frigate_ui: z.boolean().default(true),
+      fullscreen: z.boolean().default(false),
     })
     .optional(),
   entities: z

--- a/src/view.ts
+++ b/src/view.ts
@@ -28,6 +28,10 @@ export class View {
     return this.view == 'clips' || this.view == 'snapshots';
   }
 
+  public isMediaView(): boolean {
+    return !this.isGalleryView();
+  }
+
   get media(): BrowseMediaSource | undefined {
     if (this.target) {
       if (this.target.children && this.childIndex !== undefined) {


### PR DESCRIPTION
* Add a fullscreen button (shows by default) that toggles the card into fullscreen mode.
* Fullscreen mode will render all media & the gallery fullscreen, along with their controls (e.g. full screen browsing, next/previous).
* Special attention to get portrait (height > width) media to render correctly.
* Closes #70.