### PR TITLE
Much improved auto-detection of frigate camera name

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ lovelace:
 
 | Option           | Default | Description                                         |
 | ------------- | --------------------------------------------- | - |
-| `frigate_camera_name` | The string after the "camera." in the `camera_entity` option (above). | This parameter allows the camera name heuristic to be overriden for cases where the entity name does not cleanly map to the Frigate camera name (e.g. when the Frigate camera name is capitalized, but the entity name is lower case). This camera name is used for communicating with the Frigate backend, e.g. for fetching events. |
+| `frigate_camera_name` | The Frigate camera name Home Assistant associates with that camera entity, if none then the string after the `camera.` in the `camera_entity` field. | This parameter allows the Frigate camera name to be overriden. This name is used for communicating with the Frigate backend, e.g. for fetching events. |
 | `live_provider` | `frigate` | The means through which the live camera view is displayed. See [Live Provider](#live-provider) below.|
 | `view_default` | `live` | The view to show by default. See [views](#views) below.|
 | `frigate_client_id` | `frigate` | The Frigate client id to use. If this Home Assistant server has multiple Frigate server backends configured, this selects which server should be used. It should be set to the MQTT client id configured for this server, see [Frigate Integration Multiple Instance Support](https://blakeblackshear.github.io/frigate/usage/home-assistant/#multiple-instance-support).|

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -37,7 +37,7 @@ const plugins = [
     exclude: 'node_modules/**',
   }),
   dev && serve(serveopts),
-  !dev && terser(),
+  //!dev && terser(),
 ];
 
 export default [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -37,7 +37,7 @@ const plugins = [
     exclude: 'node_modules/**',
   }),
   dev && serve(serveopts),
-  //!dev && terser(),
+  !dev && terser(),
 ];
 
 export default [

--- a/src/components/gallery.ts
+++ b/src/components/gallery.ts
@@ -91,7 +91,6 @@ export class FrigateCardGallery extends LitElement {
       width: `calc(${100 / this._columns}% - 1.2px)`,
     };
 
-    console.info(this.clientWidth);
     return html` <ul class="mdc-image-list frigate-card-gallery">
       ${this.view && this.view.previous
         ? html`<li class="mdc-image-list__item" style="${styleMap(styles)}">

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -94,6 +94,7 @@
     "could_not_resolve": "Could not resolve media URL",
     "no_live_camera": "No live camera",
     "invalid_configuration": "Invalid configuration",
-    "missing_webrtc": "WebRTC component not found"
+    "missing_webrtc": "WebRTC component not found",
+    "no_frigate_camera_name": "Cannot derive frigate_camera_name, you may need to set it manually"
   }
 }

--- a/src/scss/card.scss
+++ b/src/scss/card.scss
@@ -14,6 +14,8 @@
   overflow: auto;
   -ms-overflow-style: none; /* Hide scrollbar: IE and Edge */
   scrollbar-width: none;    /* Hide scrollbar: Firefox */
+  display: flex;
+  align-items: center;
 }
 
 /* Hide scrollbar for Chrome, Safari and Opera */
@@ -52,10 +54,6 @@ ha-card {
   position: relative;
   color: var(--secondary-text-color, white);
   background-color: var(--secondary-background-color, black);
-}
-
-ha-card a {
-  color: var(--primary-text-color, white);
 }
 
 frigate-card-gallery, frigate-card-viewer, frigate-card-live {

--- a/src/scss/message.scss
+++ b/src/scss/message.scss
@@ -6,3 +6,7 @@
   box-sizing: border-box;
   padding: 10%;
 }
+
+.message a {
+  color: var(--primary-text-color, white);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,15 +98,24 @@ export const frigateCardConfigSchema = z.object({
       nextprev: z.enum(NEXT_PREVIOUS_CONTROL_STYLES).default('thumbnails'),
     })
     .optional(),
-  dimensions: z.object({
-    aspect_ratio_mode: z.enum(['dynamic', 'static', 'unconstrained']).default('dynamic'),
-    aspect_ratio:
-      z.number().array().length(2).or(
-        z.string()
-        .regex(/^\s*\d+\s*[:\/]\s*\d+\s*$/)
-        .transform((input) => input.split(/[:\/]/).map((d) => Number(d)))
-      ).default([16, 9]),
-  }).optional(),
+  dimensions: z
+    .object({
+      aspect_ratio_mode: z
+        .enum(['dynamic', 'static', 'unconstrained'])
+        .default('dynamic'),
+      aspect_ratio: z
+        .number()
+        .array()
+        .length(2)
+        .or(
+          z
+            .string()
+            .regex(/^\s*\d+\s*[:\/]\s*\d+\s*$/)
+            .transform((input) => input.split(/[:\/]/).map((d) => Number(d))),
+        )
+        .default([16, 9]),
+    })
+    .optional(),
 
   // Stock lovelace card config.
   type: z.string(),
@@ -134,6 +143,14 @@ export interface BrowseMediaQueryParameters {
   zone?: string;
   before?: number;
   after?: number;
+}
+
+export interface BrowseMediaNeighbors {
+  previous: BrowseMediaSource | null;
+  previousIndex: number | null;
+
+  next: BrowseMediaSource | null;
+  nextIndex: number | null;
 }
 
 export interface MediaLoadInfo {
@@ -182,15 +199,14 @@ export const resolvedMediaSchema = z.object({
 });
 export type ResolvedMedia = z.infer<typeof resolvedMediaSchema>;
 
-export interface BrowseMediaNeighbors {
-  previous: BrowseMediaSource | null;
-  previousIndex: number | null;
-
-  next: BrowseMediaSource | null;
-  nextIndex: number | null;
-}
-
 export const signedPathSchema = z.object({
   path: z.string(),
 });
 export type SignedPath = z.infer<typeof signedPathSchema>;
+
+export const entitySchema = z.object({
+  entity_id: z.string(),
+  unique_id: z.string(),
+  platform: z.string(),
+});
+export type Entity = z.infer<typeof entitySchema>;


### PR DESCRIPTION
 *  Users who needed to manually set `frigate_camera_name` may no longer need to do so.
 *  Use the entity `unique_id` to autodetect the true camera name. As that value cannot be changed by the user, that's substantially more likely to contain the true Frigate camera name. Fallback to the old behavior if the `unique_id`  cannot be retrieved from HomeAssistant.
 * Closes #84 
