### PR TITLE
Fix card for bleeding edge HA frontend versions and improve fullscreen logic

### DIFF
--- a/src/components/menu.ts
+++ b/src/components/menu.ts
@@ -9,6 +9,8 @@ import menuStyle from '../scss/menu.scss';
 
 type FrigateCardMenuCallback = (name: string) => void;
 
+export const MENU_HEIGHT = 46;
+
 // A menu for the Frigate card.
 @customElement('frigate-card-menu')
 export class FrigateCardMenu extends LitElement {

--- a/src/patches/ha-camera-stream.ts
+++ b/src/patches/ha-camera-stream.ts
@@ -43,13 +43,16 @@ customElements.whenDefined('ha-camera-stream').then(() => {
         return html``;
       }
 
-      // Below .src binding tweaked to work pre/post:
+      // Below .src/@load bindings tweaked to work pre/post:
       // - https://github.com/home-assistant/frontend/commit/e963735dbabdc2fea8a95aea325952560c727625
       return html`
         ${this._shouldRenderMJPEG
           ? html`
               <img
                 @load=${(e) => {
+                  if (typeof this._elementResized != 'undefined') {
+                    this._elementResized();
+                  }
                   dispatchMediaLoadEvent(this, e);
                 }}
                 .src=${

--- a/src/patches/ha-camera-stream.ts
+++ b/src/patches/ha-camera-stream.ts
@@ -43,15 +43,20 @@ customElements.whenDefined('ha-camera-stream').then(() => {
         return html``;
       }
 
+      // Below .src binding tweaked to work pre/post:
+      // - https://github.com/home-assistant/frontend/commit/e963735dbabdc2fea8a95aea325952560c727625
       return html`
         ${this._shouldRenderMJPEG
           ? html`
               <img
                 @load=${(e) => {
-                  this._elementResized();
                   dispatchMediaLoadEvent(this, e);
                 }}
-                .src=${computeMJPEGStreamUrl(this.stateObj)}
+                .src=${
+                  (typeof this._connected == 'undefined' ||
+                   this._connected)
+                  ? computeMJPEGStreamUrl(this.stateObj)
+                  : ''}
                 .alt=${`Preview of the ${computeStateName(this.stateObj)} camera.`}
               />
             `


### PR DESCRIPTION
* Adapt the patched `frigate-ha-camera-stream` to not  refer to a function that was removed in the underlying HomeAssistant frontend.
* Improve fullscreen logic for cases  when the scale-by-width default won't work correctly.
* Closes #94 