### PR TITLE
Clicking on a snapshot should search for a related clip (not a related snapshot!)

### DIFF
--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -137,6 +137,7 @@ export class FrigateCardViewer extends LitElement {
         // Fetch clips within the same second (same camera/zone/label, etc).
         const clipsAtSameTime = await browseMediaQuery(this.hass, {
           ...this.browseMediaQueryParameters,
+          mediaType: 'clips',
           before: startTime + 1,
           after: startTime,
         });


### PR DESCRIPTION
When a snapshot is loaded and `_findRelatedClips` is called, `this.browseMediaQueryParameters` has `mediaType` set to `snapshots`, which does not serve the intended purpose.