### PR TITLE
Advanced: Allow setting custom JSMPEG options

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ All variables listed are under a `live:` section.
 | `webrtc.entity` | | The RTSP entity to pass WebRTC. Specify this OR `webrtc.url` (above). |
 | `webrtc.*`| | Any other options in a `webrtc:` YAML dictionary are silently passed through to WebRTC. See [WebRTC Configuration](https://github.com/AlexxIT/WebRTC#configuration) for full details this external card provides.|
 | `actions` | | Actions to use for the `live` view. See [actions](#actions) below.|
+| `jsmpeg.options.{audio, video, pauseWhenHidden, disableGl, disableWebAssembly, preserveDrawingBuffer, progressive, throttled, chunkSize, maxAudioLag, videoBufferSize, audioBufferSize}` | | **Advanced users only**: Control the underlying [JSMPEG library options](https://github.com/phoboslab/jsmpeg#usage). This is not necessary for the vast majority of users: only set these flags if you know what you're doing, as you may entirely break video rendering in the card.|
 
 #### Available Live Providers
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,11 +127,13 @@ const actionSchema = z.union([
 ]);
 export type ActionType = z.infer<typeof actionSchema>;
 
-const actionBaseSchema = z.object({
-  tap_action: actionSchema.optional(),
-  hold_action: actionSchema.optional(),
-  double_tap_action: actionSchema.optional(),
-}).passthrough();
+const actionBaseSchema = z
+  .object({
+    tap_action: actionSchema.optional(),
+    hold_action: actionSchema.optional(),
+    double_tap_action: actionSchema.optional(),
+  })
+  .passthrough();
 export type Actions = z.infer<typeof actionBaseSchema>;
 
 const actionsSchema = z.object({
@@ -369,11 +371,35 @@ const webrtcConfigSchema = z
   .optional();
 export type WebRTCConfig = z.infer<typeof webrtcConfigSchema>;
 
+const jsmpegConfigSchema = z
+  .object({
+    options: z
+      .object({
+        // https://github.com/phoboslab/jsmpeg#usage
+        audio: z.boolean().optional(),
+        video: z.boolean().optional(),
+        pauseWhenHidden: z.boolean().optional(),
+        disableGl: z.boolean().optional(),
+        disableWebAssembly: z.boolean().optional(),
+        preserveDrawingBuffer: z.boolean().optional(),
+        progressive: z.boolean().optional(),
+        throttled: z.boolean().optional(),
+        chunkSize: z.number().optional(),
+        maxAudioLag: z.number().optional(),
+        videoBufferSize: z.number().optional(),
+        audioBufferSize: z.number().optional(),
+      })
+      .optional(),
+  })
+  .optional();
+export type JSMPEGConfig = z.infer<typeof jsmpegConfigSchema>;
+
 const liveConfigSchema = z
   .object({
     provider: z.enum(LIVE_PROVIDERS).default(liveConfigDefault.provider),
     preload: z.boolean().default(liveConfigDefault.preload),
     webrtc: webrtcConfigSchema,
+    jsmpeg: jsmpegConfigSchema,
   })
   .merge(actionsSchema)
   .default(liveConfigDefault);


### PR DESCRIPTION
Certain advanced/niche configurations may benefit from tweaking the underlying JSMPEG options. Allow the user to do so via the YAML configuration and add warnings to the README that this is not for the feint of heart.

Options: https://github.com/phoboslab/jsmpeg#usage