### PR TITLE
Fix Android clip downloading

### DIFF
--- a/src/card.ts
+++ b/src/card.ts
@@ -618,7 +618,7 @@ export class FrigateCard extends LitElement {
       return;
     }
 
-    if (navigator.userAgent.startsWith("Home Assistant/")) {
+    if (navigator.userAgent.startsWith("Home Assistant/") || navigator.userAgent.startsWith("HomeAssistant/")) {
       // Home Assistant companion apps cannot download files without opening a
       // new browser window.
       //


### PR DESCRIPTION
So turns out the iOS userAgent has a space but the Android userAgent doesn't. I tested this and the Android download button works as expected however the iOS button doesn't seem to work (nothing happens). I am wondering if the blank page doesn't work the same for iOS?

Fix for #241 