### PR TITLE
Improve JSMPEG loading experience

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@material/rtl": "^13.0.0",
     "custom-card-helpers": "^1.8.0",
     "dayjs": "^1.10.7",
-    "embla-carousel": "^5.0.1",
+    "embla-carousel": "^6.1.0",
     "home-assistant-js-websocket": "^5.11.1",
     "lit": "^2.0.2",
     "lodash-es": "^4.17.21",

--- a/src/scss/media-carousel.scss
+++ b/src/scss/media-carousel.scss
@@ -2,6 +2,12 @@
   --video-max-height: none;
 }
 
+
+.embla__container {
+  // To support adaptive height animations.
+  transition: max-height 0.5s ease;
+}
+
 .embla__slide {
   flex: 0 0 100%;
 }


### PR DESCRIPTION
* Wait until the first frame is actually decoded before removing the progress spinner to avoid the 'white square' loading experience.
* Change adaptive height handler to wait for the next browser repaint before measuring slide heights.
* Closes #243 

