### PR TITLE
Remove unnecessary JSMPEG flag

### DIFF
--- a/src/components/live.ts
+++ b/src/components/live.ts
@@ -857,7 +857,6 @@ export class FrigateCardLiveJSMPEG extends LitElement {
           canvas: this._jsmpegCanvasElement,
         },
         {
-          pauseWhenHidden: false,
           protocols: [],
           audio: false,
           videoBufferSize: 1024 * 1024 * 4,


### PR DESCRIPTION
Not necessary because of #272 .