### PR TITLE
Allow Frigate card actions to be a list

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,10 @@ See the [action
 documentation](https://www.home-assistant.io/lovelace/actions/#hold-action) for
 more information on the action options available.
 
+**Note**: The Frigate Card allows either a single action (as in stock Home
+Assistant) or list of actions to be defined for each class of user interaction
+(e.g. `tap`, `double_tap`, `hold`, etc). See [an example of multiple actions](#example-multiple-actions).
+
 ### Special Elements
 
 This card supports all [Picture Elements](https://www.home-assistant.io/lovelace/picture-elements/#icon-element) using the same syntax. The card also supports a handful of custom special elements to add special Frigate card functionality.
@@ -551,16 +555,17 @@ Parameters for the `custom:frigate-card-conditional` element:
 
 | Action name | Description |
 | - | - |
-| `custom:frigate-card-action` | Call a Frigate Card action. Acceptable values are `frigate`, `clip`, `clips`, `image`, `live`, `snapshot`, `snapshots`, `download`, `frigate_ui`, `fullscreen`.|
+| `custom:frigate-card-action` | Call a Frigate Card action. Acceptable values are `default`, `clip`, `clips`, `image`, `live`, `snapshot`, `snapshots`, `download`, `frigate_ui`, `fullscreen`, `camera_select`, `menu_toggle`.|
 
 | Value | Description |
 | - | - |
-| `frigate` | Show/hide the menu or trigger the default view. |
+| `default` | Trigger the default view. |
 | `clip`, `clips`, `image`, `live`, `snapshot`, `snapshots` | Trigger the named [view](#views).|
 |`download`|Download the displayed media.|
 |`frigate_ui`|Open the Frigate UI at the configured URL.|
 |`fullscreen`|Toggle fullscreen.| 
 |`camera_select`|Select a given camera. Takes a single additional `camera` parameter with the [camera ID](#camera-ids) of the camera to select.|
+|`menu_toggle` | Show/hide the menu (for `hidden-*` mode menus). |
 
 <a name="views"></a>
 
@@ -1108,6 +1113,29 @@ view:
 image:
   src: https://my-friage-server/api/living_room/latest.jpg
   refresh_seconds: 10
+```
+</details>
+
+<a name="example-multiple-actions"></a>
+
+### Defining multiple actions for Elements
+
+<details>
+  <summary>Expand: Changing camera and view simultaneously</summary>
+
+This example shows how to configure multiple actions for a single Frigate card user interaction, in this case both selecting a different camera and changing the view on `tap`.
+
+```yaml
+[...]
+elements:
+  - type: custom:frigate-card-menu-icon
+    icon: mdi:chair-rolling
+    tap_action:
+      - action: custom:frigate-card-action
+        frigate_card_action: camera_select
+        camera: camera.office
+      - action: custom:frigate-card-action
+        frigate_card_action: live
 ```
 </details>
 

--- a/src/components/submenu.ts
+++ b/src/components/submenu.ts
@@ -1,11 +1,11 @@
 import { CSSResultGroup, html, LitElement, TemplateResult, unsafeCSS } from 'lit';
 import { customElement, property } from 'lit/decorators';
-import { hasAction, HomeAssistant } from 'custom-card-helpers';
+import { HomeAssistant } from 'custom-card-helpers';
 import { styleMap } from 'lit/directives/style-map';
 
 import { ExtendedHomeAssistant, MenuSubmenu, MenuSubmenuItem } from '../types.js';
 import { actionHandler } from '../action-handler-directive.js';
-import { refreshDynamicStateParameters } from '../common.js';
+import { frigateCardHasAction, refreshDynamicStateParameters } from '../common.js';
 
 import submenuStyle from '../scss/submenu.scss';
 import type { Corner } from "@material/mwc-menu";
@@ -39,8 +39,8 @@ export class FrigateCardSubmenu extends LitElement {
           ev.detail.config = item;
         }}
         .actionHandler=${actionHandler({
-          hasHold: hasAction(item.hold_action),
-          hasDoubleClick: hasAction(item.double_tap_action),
+          hasHold: frigateCardHasAction(item.hold_action),
+          hasDoubleClick: frigateCardHasAction(item.double_tap_action),
         })}
       >
         ${stateParameters.title || ''}
@@ -71,8 +71,8 @@ export class FrigateCardSubmenu extends LitElement {
           slot="trigger"
           .label=${this.submenu.title || ''}
           .actionHandler=${actionHandler({
-            hasHold: hasAction(this.submenu.hold_action),
-            hasDoubleClick: hasAction(this.submenu.double_tap_action),
+            hasHold: frigateCardHasAction(this.submenu.hold_action),
+            hasDoubleClick: frigateCardHasAction(this.submenu.double_tap_action),
           })}
         >
           <ha-icon icon="${this.submenu.icon}"></ha-icon>

--- a/src/types.ts
+++ b/src/types.ts
@@ -119,7 +119,7 @@ const frigateCardCustomActionBaseSchema = customActionSchema.extend({
 });
 
 const FRIGATE_CARD_GENERAL_ACTIONS = [
-  'frigate',
+  'default',
   'clip',
   'clips',
   'image',
@@ -129,6 +129,7 @@ const FRIGATE_CARD_GENERAL_ACTIONS = [
   'download',
   'frigate_ui',
   'fullscreen',
+  'menu_toggle',
 ] as const;
 const FRIGATE_CARD_ACTIONS = [...FRIGATE_CARD_GENERAL_ACTIONS, 'camera_select'] as const;
 export type FrigateCardAction = typeof FRIGATE_CARD_ACTIONS[number];
@@ -159,17 +160,21 @@ export type ActionType = z.infer<typeof actionSchema>;
 
 const actionBaseSchema = z
   .object({
-    tap_action: actionSchema.optional(),
-    hold_action: actionSchema.optional(),
-    double_tap_action: actionSchema.optional(),
-    start_tap_action: actionSchema.optional(),
-    end_tap_action: actionSchema.optional(),
+    tap_action: actionSchema.or(actionSchema.array()).optional(),
+    hold_action: actionSchema.or(actionSchema.array()).optional(),
+    double_tap_action: actionSchema.or(actionSchema.array()).optional(),
+    start_tap_action: actionSchema.or(actionSchema.array()).optional(),
+    end_tap_action: actionSchema.or(actionSchema.array()).optional(),
   })
   // Passthrough to allow (at least) entity/camera_image to go through. This
   // card doesn't need these attributes, but handleAction() in
   // custom_card_helpers may depending on how the action is configured.
   .passthrough();
 export type Actions = z.infer<typeof actionBaseSchema>;
+export type ActionsConfig = Actions & {
+  camera_image?: string;
+  entity?: string;
+};
 
 const actionsSchema = z.object({
   actions: actionBaseSchema.optional(),
@@ -744,14 +749,6 @@ export interface BrowseMediaQueryParameters {
   zone?: string;
   before?: number;
   after?: number;
-}
-
-export interface GetFrigateCardMenuButtonParameters {
-  icon: string;
-  title: string;
-  tap_action: FrigateCardAction;
-  hold_action?: FrigateCardAction;
-  emphasize?: boolean;
 }
 
 export interface BrowseMediaNeighbors {


### PR DESCRIPTION
💥 **BREAKING-CHANGE** 💥

* Preparatory work for #294 which requires multiple actions (e.g. change camera and change view).
* Removes the action entitled 'frigate' and replaces it with two separate actions 'default' (to choose the default view) and 'menu_toggle' to toggle the menu.