### PR TITLE
Add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
I noticed that you were updating the dependencies manually, specially this one:

https://github.com/dermotduffy/frigate-hass-card/commit/85a6d23b606fc90d315eb7b4988e14a6ea515b47

Which updated from a very old version. It's hard to keep up with dependencies manually, unless we, let's say, watch the projects we use to receive emails or whatever.

So, I hope this help you!