### PR TITLE
Upload frigate-hass-card artifact on pull request

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,3 +29,9 @@ jobs:
           # Don't attempt to load into HACS (as it loads the release, not the
           # build).
           ignore: "hacs"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: frigate-hass-card
+          path: dist/frigate-hass-card.js


### PR DESCRIPTION
This should help to make it easier to test new versions without having to cloning the repository and building it by hand.

With this, one can take the zip artifact from GitHub Actions and extract the `.js` to the Home Assistant.
