### PR TITLE
Change the hover menu to only show up when the mouse is over the menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -815,7 +815,7 @@ This card supports several menu styles.
 | ------------- | --------------------------------------------- | - |
 |`hidden`| Hide the menu by default, expandable upon clicking the Frigate button. | <img src="https://raw.githubusercontent.com/dermotduffy/frigate-hass-card/main/images/menu-mode-hidden.png" alt="Menu hidden" width="400px"> |
 |`overlay`| Overlay the menu over the card contents. The Frigate button shows the default view. | <img src="https://raw.githubusercontent.com/dermotduffy/frigate-hass-card/main/images/menu-mode-overlay.png" alt="Menu overlaid" width="400px"> |
-|`hover`| Overlay the menu over the card contents when the mouse is over the card / touch on the card, otherwise it is not shown. The Frigate button shows the default view. | <img src="https://raw.githubusercontent.com/dermotduffy/frigate-hass-card/main/images/menu-mode-overlay.png" alt="Menu overlaid" width="400px"> |
+|`hover`| Overlay the menu over the card contents when the mouse is over the menu, otherwise it is not shown. The Frigate button shows the default view. | <img src="https://raw.githubusercontent.com/dermotduffy/frigate-hass-card/main/images/menu-mode-overlay.png" alt="Menu overlaid" width="400px"> |
 |`outside`| Render the menu outside the card (i.e. above it if `position` is `top`, or below it if `position` is `bottom`). The Frigate button shows the default view. | <img src="https://raw.githubusercontent.com/dermotduffy/frigate-hass-card/main/images/menu-mode-above.png" alt="Menu above" width="400px"> |
 |`none`| No menu is shown. | <img src="https://raw.githubusercontent.com/dermotduffy/frigate-hass-card/main/images/menu-mode-none.png" alt="No Menu" width="400px"> |
 

--- a/src/scss/card.scss
+++ b/src/scss/card.scss
@@ -62,8 +62,7 @@ frigate-card-menu[data-style='hover'] {
 .outer + frigate-card-menu[data-style='hover'] {
   opacity: 0;
 }
-.outer:hover + frigate-card-menu[data-style='hover'],
-frigate-card-menu[data-mode='hover']:hover {
+frigate-card-menu[data-style='hover']:hover {
   opacity: 1;
 }
 


### PR DESCRIPTION
... when the mouse is over other parts of the card, the menu will now disappear (the card is getting a bit busier, and this is one way to reduce that).

* Closes #549