### PR TITLE
Only show media players capable of casting

### DIFF
--- a/src/card.ts
+++ b/src/card.ts
@@ -36,7 +36,7 @@ import type {
   Message,
 } from './types.js';
 
-import { CAMERA_BIRDSEYE, CARD_VERSION, REPO_URL } from './const.js';
+import { CAMERA_BIRDSEYE, CARD_VERSION, MEDIA_PLAYER_SUPPORT_BROWSE_MEDIA, REPO_URL } from './const.js';
 import { FrigateCardElements } from './components/elements.js';
 import { FrigateCardImage } from './components/image.js';
 import { FRIGATE_BUTTON_MENU_ICON, FrigateCardMenu } from './components/menu.js';
@@ -475,10 +475,7 @@ export class FrigateCard extends LitElement {
       if (entity.startsWith('media_player.')) {
         const stateObj = this._hass?.states[entity];
 
-        // Taken from https://github.dev/home-assistant/frontend/blob/b5861869e39290fd2e15737e89571dfc543b3ad3/src/data/media-player.ts#L93
-        const SUPPORT_BROWSE_MEDIA = 131072;
-
-        if (stateObj && supportsFeature(stateObj, SUPPORT_BROWSE_MEDIA)) {
+        if (stateObj && supportsFeature(stateObj, MEDIA_PLAYER_SUPPORT_BROWSE_MEDIA)) {
           return true;
         }
       }

--- a/src/card.ts
+++ b/src/card.ts
@@ -86,6 +86,7 @@ import {
   getOverriddenConfig,
   getOverridesByKey,
 } from './card-condition.js';
+import { supportsFeature } from './icons/update.js';
 
 /** A note on media callbacks:
  *
@@ -470,9 +471,21 @@ export class FrigateCard extends LitElement {
       });
     }
 
-    const mediaPlayers = Object.keys(this._hass?.states || {}).filter((entity) =>
-      entity.startsWith('media_player.'),
-    );
+    const isValidMediaPlayer = (entity: string): boolean => {
+      if (entity.startsWith('media_player.')) {
+        const stateObj = this._hass?.states[entity];
+
+        // Taken from https://github.dev/home-assistant/frontend/blob/b5861869e39290fd2e15737e89571dfc543b3ad3/src/data/media-player.ts#L93
+        const SUPPORT_BROWSE_MEDIA = 131072;
+
+        if (stateObj && supportsFeature(stateObj, SUPPORT_BROWSE_MEDIA)) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    const mediaPlayers = Object.keys(this._hass?.states || {}).filter(isValidMediaPlayer);
     if (
       mediaPlayers.length &&
       (this._view?.isViewerView() ||

--- a/src/const.ts
+++ b/src/const.ts
@@ -140,3 +140,6 @@ export const CONF_DIMENSIONS_ASPECT_RATIO_MODE =
   `${CONF_DIMENSIONS}.aspect_ratio_mode` as const;
 
 export const CONF_OVERRIDES = 'overrides' as const;
+
+// Taken from https://github.dev/home-assistant/frontend/blob/b5861869e39290fd2e15737e89571dfc543b3ad3/src/data/media-player.ts#L93
+export const MEDIA_PLAYER_SUPPORT_BROWSE_MEDIA = 131072;


### PR DESCRIPTION
On my tests, only media players which supports Media Browser can play the camera stream.

This filters out, at least for me:

- ADB players
- Fully Kiosk Browser players
- Samsung TV players

The only devices left are my Sony Android TV (Chromecast built-in) and my Xiaomi Mi Box S (Chromecast built-in).

The code was heavily inspired from [here](https://github.dev/home-assistant/frontend/blob/59595aabde0b159656f6ab7adab0f1e10b47d1a8/src/components/ha-selector/ha-selector-media.ts#L81-L84), and if you have a better idea on how to reuse it, I would appreciate.

I tested it.