### PR TITLE
Add Scan mode (Have your card follow the action!)

### DIFF
--- a/src/card.ts
+++ b/src/card.ts
@@ -196,7 +196,6 @@ export class FrigateCard extends LitElement {
   // Whether the card has been successfully initialized.
   protected _initialized = false;
 
-  @state()
   protected _triggers: Map<string, Date> = new Map();
 
   /**
@@ -980,6 +979,7 @@ export class FrigateCard extends LitElement {
     const now = new Date();
     let changedCamera = false;
     let triggerChanges = false;
+    const isTriggered = !!this._triggers.size;
 
     for (const [camera, config] of this._cameras?.entries() ?? []) {
       const triggerEntities = config?.trigger_by_entities ?? [];
@@ -990,14 +990,12 @@ export class FrigateCard extends LitElement {
       const shouldUntrigger = triggerEntities.every(
         (entity) => !isTriggeredState(this._hass?.states[entity]),
       );
-
       if (shouldTrigger) {
-        this._triggers.set(camera, now);
-        triggerChanges = true;
-      } else if (shouldUntrigger) {
+        this._triggers.set(camera, now)
+      } else if (shouldUntrigger && this._triggers.has(camera)) {
         this._triggers.delete(camera);
-        triggerChanges = true;
       }
+      triggerChanges ||= (!isTriggered && shouldTrigger) || (isTriggered && !this._triggers.size);
     }
 
     if (triggerChanges && this._isAutomatedViewUpdateAllowed(true)) {

--- a/src/card.ts
+++ b/src/card.ts
@@ -1571,7 +1571,7 @@ export class FrigateCard extends LitElement {
       container: true,
       outer: true,
       triggered:
-        !!this._triggers.size && this._getConfig().view.scan.trigger_show_border,
+        !!this._triggers.size && this._getConfig().view.scan.show_trigger_status,
     };
 
     const contentClasses = {

--- a/src/card.ts
+++ b/src/card.ts
@@ -704,13 +704,6 @@ export class FrigateCard extends LitElement {
             config.trigger_by_entities.push(occupancyEntity);
           }
         }
-
-        // TODO: Remove this auto-detection information.
-        console.info(
-          `Trigger entities sensor for ${entity.entity_id} are ${JSON.stringify(
-            config.trigger_by_entities,
-          )}`,
-        );
       }
       config.trigger_by_entities = [...new Set(config.trigger_by_entities)];
 

--- a/src/card.ts
+++ b/src/card.ts
@@ -1494,10 +1494,15 @@ export class FrigateCard extends LitElement {
       outerStyle['padding-top'] = `${padding}%`;
     }
 
+    const outerClasses = {
+      container: true,
+      outer: true,
+      triggered: !!this._triggered && this._getConfig().view.scan.trigger_show_border,
+    }
+
     const contentClasses = {
       'frigate-card-contents': true,
       absolute: padding != null,
-      triggered: !!this._triggered && this._getConfig().view.scan.trigger_show_border,
     };
 
     const actions = this._getMergedActions();
@@ -1518,7 +1523,7 @@ export class FrigateCard extends LitElement {
       @frigate-card:render=${() => this.requestUpdate()}
     >
       ${renderMenuAbove ? this._renderMenu() : ''}
-      <div class="container outer" style="${styleMap(outerStyle)}">
+      <div class="${classMap(outerClasses)}" style="${styleMap(outerStyle)}">
         <div class="${classMap(contentClasses)}">
           ${this._cameras === undefined
             ? until(

--- a/src/components/image.ts
+++ b/src/components/image.ts
@@ -1,11 +1,11 @@
 import { HomeAssistant } from 'custom-card-helpers';
 import {
-  CSSResultGroup,
-  html,
-  LitElement,
-  PropertyValues,
-  TemplateResult,
-  unsafeCSS
+    CSSResultGroup,
+    html,
+    LitElement,
+    PropertyValues,
+    TemplateResult,
+    unsafeCSS
 } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { createRef, ref, Ref } from 'lit/directives/ref.js';
@@ -14,7 +14,7 @@ import defaultImage from '../images/frigate-bird-in-sky.jpg';
 import { localize } from '../localize/localize.js';
 import imageStyle from '../scss/image.scss';
 import { CameraConfig, ImageViewConfig } from '../types.js';
-import { shouldUpdateBasedOnHass } from '../utils/ha';
+import { isHassDifferent } from '../utils/ha';
 import { dispatchMediaShowEvent } from '../utils/media-info.js';
 import { View } from '../view.js';
 import { dispatchErrorMessageEvent } from './message.js';
@@ -96,7 +96,7 @@ export class FrigateCardImage extends LitElement {
       this._imageConfig?.mode === 'camera' &&
       cameraEntity
     ) {
-      if (shouldUpdateBasedOnHass(this.hass, changedProps.get('hass'), [cameraEntity])) {
+      if (isHassDifferent(this.hass, changedProps.get('hass'), [cameraEntity])) {
         // If the state of the camera entity has changed, remove the cached
         // value (will be re-calculated in willUpdate). This is important to
         // ensure a changed access token is immediately used.

--- a/src/components/live.ts
+++ b/src/components/live.ts
@@ -1090,7 +1090,8 @@ export class FrigateCardLiveJSMPEG extends LitElement {
     if (!this.cameraConfig?.camera_name) {
       return dispatchErrorMessageEvent(
         this,
-        localize('error.no_camera_name') + `: ${JSON.stringify(this.cameraConfig)}`,
+        localize('error.no_camera_name'),
+        this.cameraConfig,
       );
     }
 

--- a/src/components/submenu.ts
+++ b/src/components/submenu.ts
@@ -1,12 +1,12 @@
 import type { Corner } from '@material/mwc-menu';
 import { HomeAssistant } from 'custom-card-helpers';
 import {
-  CSSResultGroup,
-  html,
-  LitElement,
-  PropertyValues,
-  TemplateResult,
-  unsafeCSS
+    CSSResultGroup,
+    html,
+    LitElement,
+    PropertyValues,
+    TemplateResult,
+    unsafeCSS
 } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
@@ -15,10 +15,10 @@ import { actionHandler } from '../action-handler-directive.js';
 import submenuStyle from '../scss/submenu.scss';
 import { MenuSubmenu, MenuSubmenuItem, MenuSubmenuSelect } from '../types.js';
 import {
-  frigateCardHasAction,
-  stopEventFromActivatingCardWideActions
+    frigateCardHasAction,
+    stopEventFromActivatingCardWideActions
 } from '../utils/action.js';
-import { refreshDynamicStateParameters, shouldUpdateBasedOnHass } from '../utils/ha';
+import { isHassDifferent, refreshDynamicStateParameters } from '../utils/ha';
 import { domainIcon } from '../utils/icons/domain-icon.js';
 
 @customElement('frigate-card-submenu')
@@ -139,7 +139,7 @@ export class FrigateCardSubmenuSelect extends LitElement {
       changedProps.size != 1 ||
       !this.submenuSelect ||
       (!!oldHass &&
-        shouldUpdateBasedOnHass(this.hass, oldHass, [this.submenuSelect.entity]))
+        isHassDifferent(this.hass, oldHass, [this.submenuSelect.entity]))
     );
   }
 

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -37,7 +37,7 @@ import {
   overrideMultiBrowseMediaQueryParameters
 } from '../utils/ha/browse-media.js';
 import { createMediaShowInfo } from '../utils/media-info.js';
-import { ResolvedMediaCache, resolveMedia } from '../utils/resolved-media.js';
+import { ResolvedMediaCache, resolveMedia } from '../utils/ha/resolved-media.js';
 import { View } from '../view.js';
 import { AutoMediaPlugin } from './embla-plugins/automedia.js';
 import { Lazyload, LazyloadType } from './embla-plugins/lazyload.js';

--- a/src/const.ts
+++ b/src/const.ts
@@ -41,8 +41,6 @@ export const CONF_VIEW_UPDATE_ENTITIES = `${CONF_VIEW}.update_entities` as const
 export const CONF_VIEW_UPDATE_SECONDS = `${CONF_VIEW}.update_seconds` as const;
 export const CONF_VIEW_SCAN = `${CONF_VIEW}.scan` as const;
 export const CONF_VIEW_SCAN_ENABLED = `${CONF_VIEW_SCAN}.enabled` as const;
-export const CONF_VIEW_SCAN_TRIGGER_MIN_SECONDS =
-  `${CONF_VIEW_SCAN}.trigger_min_seconds` as const;
 export const CONF_VIEW_SCAN_TRIGGER_SHOW_BORDER =
   `${CONF_VIEW_SCAN}.trigger_show_border` as const;
 

--- a/src/const.ts
+++ b/src/const.ts
@@ -23,6 +23,12 @@ export const CONF_CAMERAS_ARRAY_LIVE_PROVIDER =
   `${CONF_CAMERAS}.#.live_provider` as const;
 export const CONF_CAMERAS_ARRAY_DEPENDENT_CAMERAS =
   `${CONF_CAMERAS}.#.dependent_cameras` as const;
+export const CONF_CAMERAS_ARRAY_TRIGGER_BY_MOTION =
+  `${CONF_CAMERAS}.#.trigger_by_motion` as const;
+export const CONF_CAMERAS_ARRAY_TRIGGER_BY_OCCUPANCY =
+  `${CONF_CAMERAS}.#.trigger_by_occupancy` as const;
+export const CONF_CAMERAS_ARRAY_TRIGGER_BY_ENTITIES =
+  `${CONF_CAMERAS}.#.trigger_by_entities` as const;
 
 export const CONF_VIEW = 'view' as const;
 export const CONF_VIEW_CAMERA_SELECT = `${CONF_VIEW}.camera_select` as const;
@@ -35,8 +41,10 @@ export const CONF_VIEW_UPDATE_ENTITIES = `${CONF_VIEW}.update_entities` as const
 export const CONF_VIEW_UPDATE_SECONDS = `${CONF_VIEW}.update_seconds` as const;
 export const CONF_VIEW_SCAN = `${CONF_VIEW}.scan` as const;
 export const CONF_VIEW_SCAN_ENABLED = `${CONF_VIEW_SCAN}.enabled` as const;
-export const CONF_VIEW_SCAN_TRIGGER_MIN_SECONDS = `${CONF_VIEW_SCAN}.trigger_min_seconds` as const;
-export const CONF_VIEW_SCAN_TRIGGER_SHOW_BORDER = `${CONF_VIEW_SCAN}.trigger_show_border` as const;
+export const CONF_VIEW_SCAN_TRIGGER_MIN_SECONDS =
+  `${CONF_VIEW_SCAN}.trigger_min_seconds` as const;
+export const CONF_VIEW_SCAN_TRIGGER_SHOW_BORDER =
+  `${CONF_VIEW_SCAN}.trigger_show_border` as const;
 
 export const CONF_EVENT_GALLERY = 'event_gallery' as const;
 export const CONF_EVENT_GALLERY_CONTROLS_THUMBNAILS_SHOW_DETAILS =

--- a/src/const.ts
+++ b/src/const.ts
@@ -41,8 +41,8 @@ export const CONF_VIEW_UPDATE_ENTITIES = `${CONF_VIEW}.update_entities` as const
 export const CONF_VIEW_UPDATE_SECONDS = `${CONF_VIEW}.update_seconds` as const;
 export const CONF_VIEW_SCAN = `${CONF_VIEW}.scan` as const;
 export const CONF_VIEW_SCAN_ENABLED = `${CONF_VIEW_SCAN}.enabled` as const;
-export const CONF_VIEW_SCAN_TRIGGER_SHOW_BORDER =
-  `${CONF_VIEW_SCAN}.trigger_show_border` as const;
+export const CONF_VIEW_SCAN_SHOW_TRIGGER_STATUS =
+  `${CONF_VIEW_SCAN}.show_trigger_status` as const;
 
 export const CONF_EVENT_GALLERY = 'event_gallery' as const;
 export const CONF_EVENT_GALLERY_CONTROLS_THUMBNAILS_SHOW_DETAILS =

--- a/src/const.ts
+++ b/src/const.ts
@@ -33,6 +33,10 @@ export const CONF_VIEW_UPDATE_CYCLE_CAMERA = `${CONF_VIEW}.update_cycle_camera` 
 export const CONF_VIEW_UPDATE_FORCE = `${CONF_VIEW}.update_force` as const;
 export const CONF_VIEW_UPDATE_ENTITIES = `${CONF_VIEW}.update_entities` as const;
 export const CONF_VIEW_UPDATE_SECONDS = `${CONF_VIEW}.update_seconds` as const;
+export const CONF_VIEW_SCAN = `${CONF_VIEW}.scan` as const;
+export const CONF_VIEW_SCAN_ENABLED = `${CONF_VIEW_SCAN}.enabled` as const;
+export const CONF_VIEW_SCAN_TRIGGER_MIN_SECONDS = `${CONF_VIEW_SCAN}.trigger_min_seconds` as const;
+export const CONF_VIEW_SCAN_TRIGGER_SHOW_BORDER = `${CONF_VIEW_SCAN}.trigger_show_border` as const;
 
 export const CONF_EVENT_GALLERY = 'event_gallery' as const;
 export const CONF_EVENT_GALLERY_CONTROLS_THUMBNAILS_SHOW_DETAILS =

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -86,7 +86,7 @@ import {
   CONF_VIEW_DEFAULT,
   CONF_VIEW_SCAN,
   CONF_VIEW_SCAN_ENABLED,
-  CONF_VIEW_SCAN_TRIGGER_SHOW_BORDER,
+  CONF_VIEW_SCAN_SHOW_TRIGGER_STATUS,
   CONF_VIEW_TIMEOUT_SECONDS,
   CONF_VIEW_UPDATE_CYCLE_CAMERA,
   CONF_VIEW_UPDATE_FORCE,
@@ -611,14 +611,14 @@ export class FrigateCardEditor extends LitElement implements LovelaceCardEditor 
               CONF_VIEW_SCAN_ENABLED,
               frigateCardConfigDefaults.view.scan.enabled ?? true,
               {
-                label: localize('config.view.scan.enabled'),
+                label: localize(`config.${CONF_VIEW_SCAN_ENABLED}`),
               },
             )}
             ${this._renderSwitch(
-              CONF_VIEW_SCAN_TRIGGER_SHOW_BORDER,
-              frigateCardConfigDefaults.view.scan.trigger_show_border ?? true,
+              CONF_VIEW_SCAN_SHOW_TRIGGER_STATUS,
+              frigateCardConfigDefaults.view.scan.show_trigger_status ?? true,
               {
-                label: localize('config.view.scan.trigger_show_border'),
+                label: localize(`config.${CONF_VIEW_SCAN_SHOW_TRIGGER_STATUS}`),
               },
             )}
           </div>`

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -86,7 +86,6 @@ import {
   CONF_VIEW_DEFAULT,
   CONF_VIEW_SCAN,
   CONF_VIEW_SCAN_ENABLED,
-  CONF_VIEW_SCAN_TRIGGER_MIN_SECONDS,
   CONF_VIEW_SCAN_TRIGGER_SHOW_BORDER,
   CONF_VIEW_TIMEOUT_SECONDS,
   CONF_VIEW_UPDATE_CYCLE_CAMERA,
@@ -622,10 +621,6 @@ export class FrigateCardEditor extends LitElement implements LovelaceCardEditor 
                 label: localize('config.view.scan.trigger_show_border'),
               },
             )}
-            ${this._renderNumberInput(CONF_VIEW_SCAN_TRIGGER_MIN_SECONDS, {
-              default: frigateCardConfigDefaults.view.scan.trigger_min_seconds,
-              label: localize('config.view.scan.trigger_min_seconds'),
-            })}
           </div>`
         : ''}
     `;

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -81,6 +81,10 @@ import {
   CONF_VIEW_CAMERA_SELECT,
   CONF_VIEW_DARK_MODE,
   CONF_VIEW_DEFAULT,
+  CONF_VIEW_SCAN,
+  CONF_VIEW_SCAN_ENABLED,
+  CONF_VIEW_SCAN_TRIGGER_MIN_SECONDS,
+  CONF_VIEW_SCAN_TRIGGER_SHOW_BORDER,
   CONF_VIEW_TIMEOUT_SECONDS,
   CONF_VIEW_UPDATE_CYCLE_CAMERA,
   CONF_VIEW_UPDATE_FORCE,
@@ -104,6 +108,7 @@ import { sideLoadHomeAssistantElements } from './utils/ha';
 const MENU_BUTTONS = 'buttons';
 const MENU_CAMERAS = 'cameras';
 const MENU_OPTIONS = 'options';
+const MENU_VIEW_SCAN = 'scan';
 
 interface EditorOptionsSet {
   icon: string;
@@ -601,6 +606,44 @@ export class FrigateCardEditor extends LitElement implements LovelaceCardEditor 
     );
   }
 
+  protected _renderViewScanMenu(): TemplateResult {
+    return html`
+      <div
+        class="submenu-header"
+        @click=${this._toggleMenu}
+        .domain=${MENU_VIEW_SCAN}
+        .key=${true}
+      >
+        <ha-icon .icon=${'mdi:target-account'}></ha-icon>
+        <span
+          >${localize(`config.${CONF_VIEW_SCAN}.scan_mode`)}</span
+        >
+      </div>
+      ${this._expandedMenus[MENU_VIEW_SCAN]
+        ? html` <div class="values">
+            ${this._renderSwitch(
+              CONF_VIEW_SCAN_ENABLED,
+              frigateCardConfigDefaults.view.scan.enabled ?? true,
+              {
+                label: localize('config.view.scan.enabled'),
+              },
+            )}
+            ${this._renderSwitch(
+              CONF_VIEW_SCAN_TRIGGER_SHOW_BORDER,
+              frigateCardConfigDefaults.view.scan.trigger_show_border ?? true,
+              {
+                label: localize('config.view.scan.trigger_show_border'),
+              },
+            )}
+            ${this._renderNumberInput(CONF_VIEW_SCAN_TRIGGER_MIN_SECONDS, {
+              default: frigateCardConfigDefaults.view.scan.trigger_min_seconds,
+              label: localize('config.view.scan.trigger_min_seconds'),
+            })}
+          </div>`
+        : ''}
+    `;
+  }
+
   /**
    * Render an editor menu for the card menu buttons.
    * @param button The name of the button.
@@ -985,6 +1028,7 @@ export class FrigateCardEditor extends LitElement implements LovelaceCardEditor 
                   CONF_VIEW_UPDATE_CYCLE_CAMERA,
                   defaults.view.update_cycle_camera,
                 )}
+                ${this._renderViewScanMenu()}
               </div>
             `
           : ''}

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -65,7 +65,13 @@
       "timeout_seconds": "Reset to default view X seconds after user action (0=never)",
       "update_cycle_camera": "Cycle through cameras when default view updates",
       "update_force": "Force card updates (ignore user interaction)",
-      "update_seconds": "Refresh default view every X seconds (0=never)"
+      "update_seconds": "Refresh default view every X seconds (0=never)",
+      "scan": {
+        "scan_mode": "Scan mode",
+        "enabled": "Scan mode enabled",
+        "trigger_min_seconds": "Minimum seconds to trigger for",
+        "trigger_show_border": "Show pulsing border when triggered"
+      }
     },
     "event_gallery": {
       "controls": {

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -27,6 +27,9 @@
         "frigate-jsmpeg": "Frigate JSMpeg",
         "webrtc-card": "WebRTC Card (i.e. AlexxIT's WebRTC Card)"
       },
+      "trigger_by_entities": "Trigger from other entities",
+      "trigger_by_motion": "Trigger by auto-detecting the motion sensor",
+      "trigger_by_occupancy": "Trigger by auto-detecting the occupancy sensor",
       "webrtc_card": {
         "entity": "WebRTC Card Camera Entity (Not a Frigate camera)",
         "url": "WebRTC Card Camera URL"

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -72,7 +72,7 @@
       "scan": {
         "scan_mode": "Scan mode",
         "enabled": "Scan mode enabled",
-        "trigger_show_border": "Show pulsing border when triggered"
+        "show_trigger_status": "Show pulsing border when triggered"
       }
     },
     "event_gallery": {

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -72,7 +72,6 @@
       "scan": {
         "scan_mode": "Scan mode",
         "enabled": "Scan mode enabled",
-        "trigger_min_seconds": "Minimum seconds to trigger for",
         "trigger_show_border": "Show pulsing border when triggered"
       }
     },

--- a/src/scss/card.scss
+++ b/src/scss/card.scss
@@ -23,6 +23,20 @@
   // boundary.
   border-radius: var(--ha-card-border-radius, 4px);
 }
+.container.triggered {
+  @keyframes warning-pulse {
+    0% {
+      border: solid 1px rgba(0,0,0,0);
+    }
+    50% {
+      border: solid 1px var(--warning-color);
+    }
+    100% {
+      border: solid 1px rgba(0,0,0,0);
+    }
+  }
+  animation: warning-pulse 5s infinite;  
+}
 
 .frigate-card-contents {
   width: inherit;
@@ -41,20 +55,6 @@
   scrollbar-width: none;
   // Hide scrollbar: IE and Edge
   -ms-overflow-style: none;
-}
-.frigate-card-contents.triggered {
-  @keyframes warning-pulse {
-    0% {
-      border: solid 1px rgba(0,0,0,0);
-    }
-    50% {
-      border: solid 1px var(--warning-color);
-    }
-    100% {
-      border: solid 1px rgba(0,0,0,0);
-    }
-  }
-  animation: warning-pulse 5s infinite;  
 }
 
 /* Hide scrollbar for Chrome, Safari and Opera */

--- a/src/scss/card.scss
+++ b/src/scss/card.scss
@@ -33,10 +33,28 @@
   align-items: center;
   justify-content: center;
 
+  // Include the borders in the sizing (to keep the triggered warning pulse
+  // visible in fullscreen).
+  box-sizing: border-box;
+
   // Hide scrollbar: Firefox
   scrollbar-width: none;
   // Hide scrollbar: IE and Edge
   -ms-overflow-style: none;
+}
+.frigate-card-contents.triggered {
+  @keyframes warning-pulse {
+    0% {
+      border: solid 1px rgba(0,0,0,0);
+    }
+    50% {
+      border: solid 1px var(--warning-color);
+    }
+    100% {
+      border: solid 1px rgba(0,0,0,0);
+    }
+  }
+  animation: warning-pulse 5s infinite;  
 }
 
 /* Hide scrollbar for Chrome, Safari and Opera */

--- a/src/scss/editor.scss
+++ b/src/scss/editor.scss
@@ -42,7 +42,7 @@ div.upgrade span {
 
 .submenu-header {
   display: flex;
-  margin-top: 4px;
+  margin-top: 10px;
 
   cursor: pointer;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -507,7 +507,6 @@ const viewConfigDefault = {
   dark_mode: 'off' as const,
   scan: {
     enabled: false,
-    trigger_min_seconds: 20,
     trigger_show_border: true,
   }
 };
@@ -528,7 +527,6 @@ const viewConfigSchema = z
     dark_mode: z.enum(['on', 'off', 'auto']).optional(),
     scan: z.object({
       enabled: z.boolean().default(viewConfigDefault.scan.enabled),
-      trigger_min_seconds: z.number().default(viewConfigDefault.scan.trigger_min_seconds),
       trigger_show_border: z.boolean().default(viewConfigDefault.scan.trigger_show_border),
     }).default(viewConfigDefault.scan)
   })

--- a/src/types.ts
+++ b/src/types.ts
@@ -364,6 +364,9 @@ const customSchema = z
 export const cameraConfigDefault = {
   client_id: 'frigate' as const,
   live_provider: 'auto' as const,
+  trigger_by_motion: true,
+  trigger_by_occupancy: true,
+  trigger_by_entities: [],
 };
 const webrtcCardCameraConfigSchema = z.object({
   entity: z.string().optional(),
@@ -395,9 +398,9 @@ const cameraConfigSchema = z
     // Set of cameras IDs upon which this camera depends.
     dependent_cameras: z.string().array().optional(),
 
-    trigger_by_motion: z.boolean().optional(),
-    trigger_by_occupancy: z.boolean().optional(),
-    trigger_by_entities: z.string().array().optional(),
+    trigger_by_motion: z.boolean().default(cameraConfigDefault.trigger_by_motion),
+    trigger_by_occupancy: z.boolean().default(cameraConfigDefault.trigger_by_occupancy),
+    trigger_by_entities: z.string().array().default(cameraConfigDefault.trigger_by_entities),
   })
   .default(cameraConfigDefault);
 export type CameraConfig = z.infer<typeof cameraConfigSchema>;
@@ -1263,8 +1266,18 @@ export const signedPathSchema = z.object({
 export type SignedPath = z.infer<typeof signedPathSchema>;
 
 export const entitySchema = z.object({
+  config_entry_id: z.string().nullable(),
+  disabled_by: z.string().nullable(),
   entity_id: z.string(),
-  unique_id: z.string(),
   platform: z.string(),
 });
 export type Entity = z.infer<typeof entitySchema>;
+
+export const extendedEntitySchema = entitySchema.extend({
+  // Extended entity results.
+  unique_id: z.string().optional(),
+})
+export type ExtendedEntity = z.infer<typeof extendedEntitySchema>;
+
+export const entityListSchema = entitySchema.array();
+export type EntityList = z.infer<typeof entityListSchema>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -364,7 +364,7 @@ const customSchema = z
 export const cameraConfigDefault = {
   client_id: 'frigate' as const,
   live_provider: 'auto' as const,
-  trigger_by_motion: true,
+  trigger_by_motion: false,
   trigger_by_occupancy: true,
   trigger_by_entities: [],
 };
@@ -507,7 +507,7 @@ const viewConfigDefault = {
   dark_mode: 'off' as const,
   scan: {
     enabled: false,
-    trigger_show_border: true,
+    show_trigger_status: true,
   }
 };
 const viewConfigSchema = z
@@ -527,7 +527,7 @@ const viewConfigSchema = z
     dark_mode: z.enum(['on', 'off', 'auto']).optional(),
     scan: z.object({
       enabled: z.boolean().default(viewConfigDefault.scan.enabled),
-      trigger_show_border: z.boolean().default(viewConfigDefault.scan.trigger_show_border),
+      show_trigger_status: z.boolean().default(viewConfigDefault.scan.show_trigger_status),
     }).default(viewConfigDefault.scan)
   })
   .merge(actionsSchema)

--- a/src/types.ts
+++ b/src/types.ts
@@ -394,6 +394,10 @@ const cameraConfigSchema = z
 
     // Set of cameras IDs upon which this camera depends.
     dependent_cameras: z.string().array().optional(),
+
+    trigger_by_motion: z.boolean().optional(),
+    trigger_by_occupancy: z.boolean().optional(),
+    trigger_by_entities: z.string().array().optional(),
   })
   .default(cameraConfigDefault);
 export type CameraConfig = z.infer<typeof cameraConfigSchema>;
@@ -498,6 +502,11 @@ const viewConfigDefault = {
   update_force: false,
   update_cycle_camera: false,
   dark_mode: 'off' as const,
+  scan: {
+    enabled: false,
+    trigger_min_seconds: 20,
+    trigger_show_border: true,
+  }
 };
 const viewConfigSchema = z
   .object({
@@ -514,6 +523,11 @@ const viewConfigSchema = z
     update_entities: z.string().array().optional(),
     render_entities: z.string().array().optional(),
     dark_mode: z.enum(['on', 'off', 'auto']).optional(),
+    scan: z.object({
+      enabled: z.boolean().default(viewConfigDefault.scan.enabled),
+      trigger_min_seconds: z.number().default(viewConfigDefault.scan.trigger_min_seconds),
+      trigger_show_border: z.boolean().default(viewConfigDefault.scan.trigger_show_border),
+    }).default(viewConfigDefault.scan)
   })
   .merge(actionsSchema)
   .default(viewConfigDefault);

--- a/src/utils/ha/entity-registry.ts
+++ b/src/utils/ha/entity-registry.ts
@@ -1,0 +1,109 @@
+import { HomeAssistant } from 'custom-card-helpers';
+import { homeAssistantWSRequest } from '.';
+import {
+  Entity,
+  EntityList,
+  entityListSchema,
+  ExtendedEntity,
+  extendedEntitySchema
+} from '../../types.js';
+
+export class ExtendedEntityCache {
+  protected _cache: Map<string, ExtendedEntity> = new Map();
+
+  /**
+   * Determine if the cache has a given entity_id.
+   * @param id
+   * @returns `true` if the id is in the cache, `false` otherwise.
+   */
+  public has(id: string): boolean {
+    return this._cache.has(id);
+  }
+
+  /**
+   * Get the first value that returns true for the given predicate.
+   * @param func A callback function that returns a boolean.
+   * @returns The first matching value.
+   */
+  public getMatch(func: (arg: ExtendedEntity) => boolean): ExtendedEntity | null {
+    return [...this._cache.values()].find(func) ?? null;
+  }
+
+  /**
+   * Get entity information given an id.
+   * @param id The entity id.
+   * @returns The `ExtendedEntity` for this id.
+   */
+  public get(id: string): ExtendedEntity | undefined {
+    return this._cache.get(id);
+  }
+
+  /**
+   * Add a given ExtendedEntity to the cache.
+   * @param extendedEntity
+   */
+  public set(extendedEntity: ExtendedEntity): void {
+    this._cache.set(extendedEntity.entity_id, extendedEntity);
+  }
+}
+
+/**
+ * Get the extended entity information for an entity. May throw.
+ * @param hass The Home Assistant object.
+ * @param entity The entity id.
+ * @param cache An optional ExtendedEntityCache.
+ * @returns The ExtendedEntity information.
+ */
+export const getExtendedEntity = async (
+  hass: HomeAssistant,
+  entity: string,
+  cache?: ExtendedEntityCache,
+): Promise<ExtendedEntity> => {
+  const cachedValue = cache ? cache.get(entity) : undefined;
+  if (cachedValue) {
+    return cachedValue;
+  }
+  const result = await homeAssistantWSRequest<ExtendedEntity>(
+    hass,
+    extendedEntitySchema,
+    {
+      type: 'config/entity_registry/get',
+      entity_id: entity,
+    },
+  );
+  if (cache) {
+    cache.set(result);
+  }
+  return result;
+};
+
+/**
+ * Get the extended entity information for an array of entities.
+ * @param hass The Home Assistant object.
+ * @param entities An array of entity ids.
+ * @param cache An optional ExtendedEntityCache.
+ * @returns A map of entity id to ExtendedEntity objects.
+ */
+export const getExtendedEntities = async (
+  hass: HomeAssistant,
+  entities: string[],
+  cache?: ExtendedEntityCache,
+): Promise<Map<string, Entity>> => {
+  const output: Map<string, Entity> = new Map();
+  const _storeExtendedEntity = async (entity: string): Promise<void> => {
+    output.set(entity, await getExtendedEntity(hass, entity, cache));
+  };
+  await Promise.all(entities.map(_storeExtendedEntity));
+  return output;
+};
+
+/**
+ * Get a list of all entities from the entity registry.
+ * @param hass The Home Assistant object.
+ * @returns An entity list object.
+ */
+export const getAllEntities = async (hass: HomeAssistant): Promise<EntityList> => {
+  return await homeAssistantWSRequest<EntityList>(hass, entityListSchema, {
+    type: 'config/entity_registry/list',
+  });
+};

--- a/src/utils/ha/index.ts
+++ b/src/utils/ha/index.ts
@@ -105,10 +105,10 @@ export function getHassDifferences(
 
   const differences: HassStateDifference[] = [];
   for (const entity of entities) {
-    const oldState = oldHass?.states[entity];
-    const newState = newHass.states[entity];
+    const oldState: HassEntity | undefined = oldHass?.states[entity];
+    const newState: HassEntity | undefined = newHass.states[entity];
     if (
-      (options?.stateOnly && oldState?.state !== newState.state) ||
+      (options?.stateOnly && oldState?.state !== newState?.state) ||
       (!options?.stateOnly && oldState !== newState)
     ) {
       differences.push({

--- a/src/utils/ha/index.ts
+++ b/src/utils/ha/index.ts
@@ -4,8 +4,7 @@ import { StyleInfo } from 'lit/directives/style-map.js';
 import { ZodSchema } from 'zod';
 import { localize } from '../../localize/localize.js';
 import {
-  CardHelpers,
-  ExtendedHomeAssistant,
+  CardHelpers, ExtendedHomeAssistant,
   SignedPath,
   signedPathSchema,
   StateParameters
@@ -306,3 +305,20 @@ export const sideLoadHomeAssistantElements = async (): Promise<boolean> => {
 export const isTriggeredState = (state?: HassEntity): boolean => {
   return !!state && ['on', 'open'].includes(state.state);
 };
+
+/**
+ * Get entities from the HASS object.
+ * @param hass 
+ * @param domain 
+ * @returns 
+ */
+export const getEntitiesFromHASS = (hass: HomeAssistant, domain?: string): string[] => {
+  if (!hass) {
+    return [];
+  }
+  const entities = Object.keys(hass.states).filter(
+    (eid) => !domain || eid.substr(0, eid.indexOf('.')) === domain,
+  );
+  entities.sort();
+  return entities;
+}

--- a/src/utils/ha/resolved-media.ts
+++ b/src/utils/ha/resolved-media.ts
@@ -1,11 +1,11 @@
 import { HomeAssistant } from 'custom-card-helpers';
 import QuickLRU from 'quick-lru';
+import { homeAssistantWSRequest } from '.';
 import {
-  FrigateBrowseMediaSource,
-  ResolvedMedia,
-  resolvedMediaSchema
-} from '../types.js';
-import { homeAssistantWSRequest } from './ha';
+    FrigateBrowseMediaSource,
+    ResolvedMedia,
+    resolvedMediaSchema
+} from '../../types.js';
 
 // It's important the cache size be at least as large as the largest likely
 // media query or media items will from a given query will be evicted for other
@@ -21,19 +21,42 @@ export class ResolvedMediaCache {
     this._cache = new QuickLRU({ maxSize: RESOLVED_MEDIA_CACHE_SIZE });
   }
 
+  /**
+   * Determine if the cache has a given id.
+   * @param id
+   * @returns `true` if the id is in the cache, `false` otherwise.
+   */
   public has(id: string): boolean {
     return this._cache.has(id);
   }
 
+
+  /**
+   * Get resolved media information given an id.
+   * @param id The id.
+   * @returns The `ResolvedMedia` for this id.
+   */
   public get(id: string): ResolvedMedia | undefined {
     return this._cache.get(id);
   }
 
+  /**
+   * Add a given ResolvedMedia to the cache.
+   * @param id The id for the object.
+   * @param resolvedMedia The `ResolvedMedia` object.
+   */
   public set(id: string, resolvedMedia: ResolvedMedia): void {
     this._cache.set(id, resolvedMedia);
   }
 }
 
+/**
+ * Resolve a given media source item.
+ * @param hass The Home Assistant object.
+ * @param mediaSource The media source object.
+ * @param cache An optional ResolvedMediaCache object.
+ * @returns 
+ */
 export const resolveMedia = async (
   hass: HomeAssistant,
   mediaSource?: FrigateBrowseMediaSource,


### PR DESCRIPTION
A new option to have the camera autodetect the occupancy/motion sensors for Frigate cameras, and have the card automatically choose `live` view for that camera when action is reported.