### PR TITLE
Show thumbnail drawer by default in live and media viewer views

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -630,9 +630,9 @@ const liveConfigDefault = {
     thumbnails: {
       media: 'clips' as const,
       size: 100,
-      show_details: false,
+      show_details: true,
       show_controls: true,
-      mode: 'none' as const,
+      mode: 'left' as const,
     },
     title: {
       mode: 'popup-bottom-right' as const,
@@ -833,9 +833,9 @@ const viewerConfigDefault = {
     },
     thumbnails: {
       size: 100,
-      mode: 'none' as const,
-      show_details: false,
+      show_details: true,
       show_controls: true,
+      mode: 'left' as const,
     },
     title: {
       mode: 'popup-bottom-right' as const,


### PR DESCRIPTION
**Motivation**: With the new thumbnail drawer the intrusion into the video frame is minimal, and this is useful and interesting functionality that most users probably would benefit from (and can turn off if not).

Disagree? Let me know.