### PR TITLE
For now remove dependabot for node packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,6 @@
 version: 2
 
 updates:
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: daily
-
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
I would rather sync the dependencies manually which each card release, so I can control & test the results. Would rather continue to receive github-actions updates in this way.