### PR TITLE
Remove entity id from cast submenu

### DIFF
--- a/src/card.ts
+++ b/src/card.ts
@@ -537,7 +537,7 @@ export class FrigateCard extends LitElement {
           entity: playerEntityID,
           state_color: false,
           title: title,
-          subtitle: title === playerEntityID ? undefined : playerEntityID,
+          subtitle: undefined,
           disabled: !state || state.state === 'unavailable',
           ...(playAction && { tap_action: playAction }),
           ...(stopAction && { hold_action: stopAction }),

--- a/src/card.ts
+++ b/src/card.ts
@@ -537,7 +537,6 @@ export class FrigateCard extends LitElement {
           entity: playerEntityID,
           state_color: false,
           title: title,
-          subtitle: undefined,
           disabled: !state || state.state === 'unavailable',
           ...(playAction && { tap_action: playAction }),
           ...(stopAction && { hold_action: stopAction }),


### PR DESCRIPTION
Because this is more backend information than a frontend one.

## Before

![image](https://user-images.githubusercontent.com/29582865/172535579-f4c21b58-7f5d-45d6-8d34-3f2f3a722f09.png)

## After

![image](https://user-images.githubusercontent.com/29582865/172535750-97943414-c0fd-44fb-8f78-0981cc161aee.png)

