### PR TITLE
Use a proper ISO8601 formatted date to fix the timeline in Safari/iOS.

### DIFF
--- a/src/utils/frigate.ts
+++ b/src/utils/frigate.ts
@@ -34,7 +34,7 @@ const recordingSummarySchema = z
     day: z.preprocess((arg) => {
       // Must provide the hour:minute:second on parsing or Javascript will
       // assume UTC midnight.
-      return typeof arg === 'string' ? new Date(`${arg} 00:00:00`) : arg;
+      return typeof arg === 'string' ? new Date(`${arg}T00:00:00`) : arg;
     }, z.date()),
     events: z.number(),
     hours: recordingSummaryHourSchema.array(),


### PR DESCRIPTION
* Closes #668