### PR TITLE
Don't support card-wide actions when a message is displayed

### DIFF
--- a/README.md
+++ b/README.md
@@ -932,7 +932,8 @@ next/previous controls, thumbnails, etc), but in some cases this is not possible
 (e.g. embedded WebRTC card controls) -- in these cases duplicate actions may
 occur with certain configurations (e.g. `tap`).
 
-**Note:** Card-wide actions are not supported on the timeline view.
+**Note:** Card-wide actions are not supported on the timeline view, nor when a
+info/error message is being displayed.
 
 ## Menu Styles
 

--- a/src/card.ts
+++ b/src/card.ts
@@ -1695,7 +1695,7 @@ export class FrigateCard extends LitElement {
    * @returns A combined set of action.
    */
   protected _getMergedActions(): Actions {
-    if (this._view?.is('timeline')) {
+    if (this._message || this._view?.is('timeline')) {
       // Timeline does not support actions as it is not possible to prevent
       // touch actions on the timeline surface from triggering card-wide actions
       // inappropriately, whilst also maintaining touch interaction with the


### PR DESCRIPTION
When card-wide actions are enabled it makes it difficult or impossible to interact with the text of the message (e.g. to copy the diagnostics text).

* Closes #717 