### PR TITLE
Embed thumbnails

### DIFF
--- a/src/components/gallery.ts
+++ b/src/components/gallery.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { HomeAssistant } from 'custom-card-helpers';
 import {
   css,
   CSSResultGroup,
@@ -12,7 +13,6 @@ import { customElement, property } from 'lit/decorators.js';
 import galleryStyle from '../scss/gallery.scss';
 import {
   CameraConfig,
-  ExtendedHomeAssistant,
   frigateCardConfigDefaults,
   GalleryConfig,
   THUMBNAIL_WIDTH_MAX,
@@ -31,7 +31,7 @@ import { THUMBNAIL_DETAILS_WIDTH_MIN } from './thumbnail.js';
 @customElement('frigate-card-gallery')
 export class FrigateCardGallery extends LitElement {
   @property({ attribute: false })
-  public hass?: ExtendedHomeAssistant;
+  public hass?: HomeAssistant;
 
   @property({ attribute: false })
   public view?: Readonly<View>;
@@ -109,7 +109,7 @@ export class FrigateCardGallery extends LitElement {
 @customElement('frigate-card-gallery-core')
 export class FrigateCardGalleryCore extends LitElement {
   @property({ attribute: false })
-  public hass?: ExtendedHomeAssistant;
+  public hass?: HomeAssistant;
 
   @property({ attribute: false })
   public view?: Readonly<View>;

--- a/src/components/live.ts
+++ b/src/components/live.ts
@@ -139,19 +139,6 @@ export class FrigateCardLive extends LitElement {
   }
 
   /**
-   * Determine whether the element should be updated.
-   * @param _changedProps The changed properties if any.
-   * @returns `true` if the element should be updated.
-   */  
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected shouldUpdate(_changedProps: PropertyValues): boolean {
-    // Don't process updates if it's in the background and a message was
-    // received (otherwise an error message thrown by the background live
-    // component may continually be re-spammed hitting performance).
-    return !this._inBackground || !this._messageReceivedPostRender;
-  }
-
-  /**
    * Component connected callback.
    */
   connectedCallback(): void {

--- a/src/components/surround-thumbnails.ts
+++ b/src/components/surround-thumbnails.ts
@@ -1,3 +1,4 @@
+import { HomeAssistant } from 'custom-card-helpers';
 import {
   CSSResultGroup,
   html,
@@ -11,7 +12,6 @@ import surroundThumbnailsStyle from '../scss/surround.scss';
 import {
   BrowseMediaQueryParameters,
   CameraConfig,
-  ExtendedHomeAssistant,
   FrigateBrowseMediaSource,
   FrigateCardError,
   FrigateCardView,
@@ -30,7 +30,7 @@ import { ThumbnailCarouselTap } from './thumbnail-carousel.js';
 @customElement('frigate-card-surround-thumbnails')
 export class FrigateCardSurround extends LitElement {
   @property({ attribute: false })
-  public hass?: ExtendedHomeAssistant;
+  public hass?: HomeAssistant;
 
   @property({ attribute: false })
   public view?: Readonly<View>;

--- a/src/components/thumbnail-carousel.ts
+++ b/src/components/thumbnail-carousel.ts
@@ -1,3 +1,4 @@
+import { HomeAssistant } from 'custom-card-helpers';
 import { EmblaOptionsType, EmblaPluginType } from 'embla-carousel';
 import { WheelGesturesPlugin } from 'embla-carousel-wheel-gestures';
 import {
@@ -14,7 +15,6 @@ import { createRef, ref, Ref } from 'lit/directives/ref.js';
 import thumbnailCarouselStyle from '../scss/thumbnail-carousel.scss';
 import {
   CameraConfig,
-  ExtendedHomeAssistant,
   FrigateBrowseMediaSource,
   ThumbnailsControlConfig,
 } from '../types.js';
@@ -36,7 +36,7 @@ export interface ThumbnailCarouselTap {
 @customElement('frigate-card-thumbnail-carousel')
 export class FrigateCardThumbnailCarousel extends LitElement {
   @property({ attribute: false })
-  public hass?: ExtendedHomeAssistant;
+  public hass?: HomeAssistant;
 
   @property({ attribute: false })
   public view?: Readonly<View>;

--- a/src/scss/thumbnail-feature-event.scss
+++ b/src/scss/thumbnail-feature-event.scss
@@ -8,8 +8,7 @@ img {
 }
 
 img,
-ha-icon,
-frigate-card-progress-indicator {
+ha-icon {
   border-radius: var(--ha-card-border-radius, 4px);
 
   max-width: var(--frigate-card-thumbnail-size);

--- a/src/utils/ha/browse-media.ts
+++ b/src/utils/ha/browse-media.ts
@@ -86,7 +86,23 @@ export const browseMedia = async (
     type: 'media_source/browse_media',
     media_content_id: media_content_id,
   };
-  return await homeAssistantWSRequest(hass, frigateBrowseMediaSourceSchema, request);
+  const root = await homeAssistantWSRequest<FrigateBrowseMediaSource>(hass, frigateBrowseMediaSourceSchema, request);
+  const embedPromises: Promise<void>[] = [];
+  const embedThumbnail = async (src: FrigateBrowseMediaSource) => {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    src.thumbnail = await hass.fetchWithAuth(src.thumbnail!)
+        .then((response) => response.blob())
+        .then((blob) => { return URL.createObjectURL(blob); });
+  }
+  const embedThumbnailandTraverse = async (parent: FrigateBrowseMediaSource) => {
+    if (parent.thumbnail) {
+      embedPromises.push(embedThumbnail(parent));
+    }
+    parent.children?.forEach((child) => embedThumbnailandTraverse(child));
+  }
+  embedThumbnailandTraverse(root);
+  await Promise.all(embedPromises);
+  return root;
 };
 
 /**

--- a/src/utils/ha/browse-media.ts
+++ b/src/utils/ha/browse-media.ts
@@ -91,14 +91,14 @@ export const browseMedia = async (
   const embedThumbnail = async (src: FrigateBrowseMediaSource) => {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     src.thumbnail = await hass.fetchWithAuth(src.thumbnail!)
-        .then((response) => response.blob())
-        .then((blob) => { return URL.createObjectURL(blob); });
+        .then(response => response.blob())
+        .then(blob => URL.createObjectURL(blob));
   }
   const embedThumbnailandTraverse = async (parent: FrigateBrowseMediaSource) => {
     if (parent.thumbnail) {
       embedPromises.push(embedThumbnail(parent));
     }
-    parent.children?.forEach((child) => embedThumbnailandTraverse(child));
+    parent.children?.forEach(child => embedThumbnailandTraverse(child));
   }
   embedThumbnailandTraverse(root);
   await Promise.all(embedPromises);


### PR DESCRIPTION
Follow up/improvement to #780 
This PR does not require any changes to the integration, and it actually uses cache properly when preloading thumbnails. It should exhibit good latency, especially after the first load.
Details:
After https://github.com/blakeblackshear/frigate-hass-integration/pull/326 was merged, the thumbnails endpoint no longer uses the service worker cache. This is actually good as the service worker cache is flawed when using "ignoreSearch:true". Instead, the service worker uses the NetworkOnly() strategy, which checks the regular http cache before going to the network.
However, the http cache does not work with signed urls.
This PR uses `hass.fetchWithAuth()` to avoid using signed urls, instead fetching the assets with a refresh token in the header. This allows the http cache to function properly.