### PR TITLE
Allow elements to be hidden when media is not yet loaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,6 +709,7 @@ All variables listed are under a `conditions:` section.
 | `camera` | A list of camera ids in which this condition is satisfied. See [camera IDs](#camera-ids).|
 | `fullscreen` | If `true` the condition is satisfied if the card is in fullscreen mode. If `false` the condition is satisfied if the card is **NOT** in fullscreen mode.|
 | `state` | A list of state conditions to compare with Home Assistant state. See below. |
+| `mediaLoaded` | If `true` the condition is satisfied if there is media load**ED** (not load**ING**) in the card (e.g. a clip, snapshot or live view). This may be used to hide controls during media loading or when a message (not media) is being displayed. Note that if `true` this condition will never be satisfied for views that do not themselves load media directly (e.g. gallery).|
 
 See the [PTZ example below](#frigate-card-conditional-example) for a real-world example of how these conditions can be used.
 
@@ -1592,7 +1593,7 @@ elements:
       scene.kitchen_tv_scene:
         icon: mdi:television
         title: TV!
-    # Show a pig icon if the card is in the live view, in fullscreen mode and light.office_main_lights is on.
+    # Show a pig icon if the card is in the live view, in fullscreen mode, light.office_main_lights is on and the media has been loaded.
   - type: custom:frigate-card-conditional
     elements:
       - type: icon
@@ -1611,6 +1612,7 @@ elements:
         - entity: light.office_main_lights
           state: on
           state_not: off
+      mediaLoaded: true
 ```
 </details>
 

--- a/src/card-condition.ts
+++ b/src/card-condition.ts
@@ -11,6 +11,7 @@ export interface ConditionState {
   fullscreen?: boolean;
   camera?: string;
   state?: HassEntities;
+  mediaLoaded?: boolean;
 }
 
 class ConditionStateRequestEvent extends Event {
@@ -47,6 +48,10 @@ export function evaluateCondition(
             (!stateTest.state_not ||
               state.state[stateTest.entity].state !== stateTest.state_not)));
     }
+  }
+  if (condition?.mediaLoaded !== undefined) {
+    result &&=
+      state.mediaLoaded !== undefined && condition.mediaLoaded == state.mediaLoaded;
   }
   return result;
 }

--- a/src/card.ts
+++ b/src/card.ts
@@ -99,6 +99,7 @@ import { supportsFeature } from './utils/ha/update.js';
 import { isValidMediaShowInfo } from './utils/media-info.js';
 import { View } from './view.js';
 import pkg from '../package.json';
+import { ViewContext } from 'view';
 
 /** A note on media callbacks:
  *
@@ -184,8 +185,9 @@ export class FrigateCard extends LitElement {
   // Automated refreshes of the default view.
   protected _updateTimerID: number | null = null;
 
-  // Information about the most recently loaded media item.
-  protected _mediaShowInfo: MediaShowInfo | null = null;
+  // Information about loaded media items.
+  protected _currentMediaShowInfo: MediaShowInfo | null = null;
+  protected _lastValidMediaShowInfo: MediaShowInfo | null = null;
 
   // Array of dynamic menu buttons to be added to menu.
   protected _dynamicMenuButtons: MenuButton[] = [];
@@ -331,7 +333,11 @@ export class FrigateCard extends LitElement {
       for (const action of actions) {
         // All frigate card actions will have action of 'fire-dom-event' and
         // styling only applies to those.
-        if (!action || action.action !== 'fire-dom-event' || !('frigate_card_action' in action)) {
+        if (
+          !action ||
+          action.action !== 'fire-dom-event' ||
+          !('frigate_card_action' in action)
+        ) {
           continue;
         }
         const frigateCardAction = action as FrigateCardCustomAction;
@@ -925,6 +931,15 @@ export class FrigateCard extends LitElement {
   }
 
   protected _changeView(args?: { view?: View; resetMessage?: boolean }): void {
+    const changeView = (view: View): void => {
+      if (View.isMediaChange(this._view, view)) {
+        this._currentMediaShowInfo = null;
+      }
+      this._view = view;
+      this._generateConditionState();
+      this._resetMainScroll();
+    };
+
     if (args?.resetMessage ?? true) {
       this._message = null;
     }
@@ -945,21 +960,19 @@ export class FrigateCard extends LitElement {
       }
 
       if (camera) {
-        this._view = new View({
-          view: this._getConfig().view.default,
-          camera: camera,
-        });
-        this._generateConditionState();
-        this._resetMainScroll();
+        changeView(
+          new View({
+            view: this._getConfig().view.default,
+            camera: camera,
+          }),
+        );
 
         // Restart the update timer, so the default view is refreshed at a fixed
         // interval from now (if so configured).
         this._startUpdateTimer();
       }
     } else {
-      this._view = args.view;
-      this._generateConditionState();
-      this._resetMainScroll();
+      changeView(args.view);
     }
   }
 
@@ -987,6 +1000,15 @@ export class FrigateCard extends LitElement {
     this._changeView({ view: e.detail });
   }
 
+  /**
+   * Add view context to the current view.
+   * @param ev A ViewContext event.
+   */
+  protected _addViewContextHandler(ev: CustomEvent<ViewContext>): void {
+    this._changeView({
+      view: this._view?.clone().mergeInContext(ev.detail),
+    });
+  }
   /**
    * Called before each update.
    */
@@ -1592,7 +1614,7 @@ export class FrigateCard extends LitElement {
    */
   protected _resetMainScroll(): void {
     // Reset the scroll on the main div to the top.
-    this._refMain.value?.scroll({top: 0});
+    this._refMain.value?.scroll({ top: 0 });
   }
 
   /**
@@ -1614,19 +1636,11 @@ export class FrigateCard extends LitElement {
     if (!isValidMediaShowInfo(mediaShowInfo)) {
       return;
     }
-    let requestRefresh = false;
-    if (
-      this._view?.isGalleryView() &&
-      (mediaShowInfo.width != this._mediaShowInfo?.width ||
-        mediaShowInfo.height != this._mediaShowInfo?.height)
-    ) {
-      requestRefresh = true;
-    }
 
-    this._mediaShowInfo = mediaShowInfo;
-    if (requestRefresh) {
-      this.requestUpdate();
-    }
+    this._lastValidMediaShowInfo = this._currentMediaShowInfo = mediaShowInfo;
+
+    // An update may be required to draw elements.
+    this.requestUpdate();
   }
 
   /**
@@ -1702,8 +1716,8 @@ export class FrigateCard extends LitElement {
     }
 
     const aspectRatioMode = this._getConfig().dimensions.aspect_ratio_mode;
-    if (aspectRatioMode == 'dynamic' && this._mediaShowInfo) {
-      return `${this._mediaShowInfo.width} / ${this._mediaShowInfo.height}`;
+    if (aspectRatioMode == 'dynamic' && this._lastValidMediaShowInfo) {
+      return `${this._lastValidMediaShowInfo.width} / ${this._lastValidMediaShowInfo.height}`;
     }
 
     const defaultAspectRatio = this._getConfig().dimensions.aspect_ratio;
@@ -1776,16 +1790,14 @@ export class FrigateCard extends LitElement {
       style="${styleMap(cardStyle)}"
       @action=${(ev: CustomEvent) => this._actionHandler(ev, actions)}
       @ll-custom=${this._cardActionHandler.bind(this)}
-      @frigate-card:message=${this._messageHandler}
-      @frigate-card:change-view=${this._changeViewHandler}
+      @frigate-card:message=${this._messageHandler.bind(this)}
+      @frigate-card:view:change=${this._changeViewHandler.bind(this)}
+      @frigate-card:view:change-context=${this._addViewContextHandler.bind(this)}
       @frigate-card:media-show=${this._mediaShowHandler}
       @frigate-card:render=${() => this.requestUpdate()}
     >
       ${renderMenuAbove ? this._renderMenu() : ''}
-      <div 
-        ${ref(this._refMain)}
-        class="main"
-      >
+      <div ${ref(this._refMain)} class="main">
         ${this._cameras === undefined && !this._message
           ? until(
               (async () => {
@@ -1807,9 +1819,12 @@ export class FrigateCard extends LitElement {
         }
       </div>
       ${!renderMenuAbove ? this._renderMenu() : ''}
-      ${!this._message && this._getConfig().elements
+      ${!this._message &&
+      (!this._view?.isAnyMediaView() || this._currentMediaShowInfo) &&
+      this._getConfig().elements
         ? // Elements need to render after the main views so it can render 'on
-          // top'.
+          // top', but only if the view is a non-media view or the media is
+          // already loaded.
           html` <frigate-card-elements
             ${ref(this._refElements)}
             .hass=${this._hass}
@@ -1925,8 +1940,8 @@ export class FrigateCard extends LitElement {
    * @returns The Lovelace card size in units of 50px.
    */
   public getCardSize(): number {
-    if (this._mediaShowInfo) {
-      return this._mediaShowInfo.height / 50;
+    if (this._lastValidMediaShowInfo) {
+      return this._lastValidMediaShowInfo.height / 50;
     }
     return 6;
   }

--- a/src/card.ts
+++ b/src/card.ts
@@ -279,6 +279,7 @@ export class FrigateCard extends LitElement {
       fullscreen: screenfull.isEnabled && screenfull.isFullscreen,
       camera: this._view?.camera,
       state: this._hass?.states,
+      mediaLoaded: !!this._currentMediaShowInfo,
     };
 
     // Update the components that need the new condition state. Passed directly
@@ -1640,6 +1641,7 @@ export class FrigateCard extends LitElement {
     this._lastValidMediaShowInfo = this._currentMediaShowInfo = mediaShowInfo;
 
     // An update may be required to draw elements.
+    this._generateConditionState();
     this.requestUpdate();
   }
 
@@ -1819,12 +1821,9 @@ export class FrigateCard extends LitElement {
         }
       </div>
       ${!renderMenuAbove ? this._renderMenu() : ''}
-      ${!this._message &&
-      (!this._view?.isAnyMediaView() || this._currentMediaShowInfo) &&
-      this._getConfig().elements
+      ${this._getConfig().elements
         ? // Elements need to render after the main views so it can render 'on
-          // top', but only if the view is a non-media view or the media is
-          // already loaded.
+          // top'.
           html` <frigate-card-elements
             ${ref(this._refElements)}
             .hass=${this._hass}

--- a/src/components/media-carousel.ts
+++ b/src/components/media-carousel.ts
@@ -363,6 +363,16 @@ export class FrigateCardMediaCarousel extends LitElement {
         @frigate-card:carousel:select=${(ev: CustomEvent<CarouselSelect>) => {
           this._slideResizeObserver.disconnect();
           this._slideResizeObserver.observe(ev.detail.element);
+
+          // Pass up the media-carousel select event first to allow parents to
+          // initialize/reset before the media info is dispatched.
+          dispatchFrigateCardEvent<CarouselSelect>(
+            this,
+            'media-carousel:select',
+            ev.detail,
+          );
+
+          // Dispatch media info.
           this._dispatchMediaShowInfo();
         }}
         @frigate-card:carousel:media-show=${this._storeMediaShowInfo.bind(this)}

--- a/src/components/surround-thumbnails.ts
+++ b/src/components/surround-thumbnails.ts
@@ -27,6 +27,17 @@ import { dispatchFrigateCardErrorEvent } from './message.js';
 import './surround.js';
 import { ThumbnailCarouselTap } from './thumbnail-carousel.js';
 
+interface ThumbnailViewContext {
+  // Whetherr or not to fetch thumbnails.
+  fetch?: boolean;
+}
+
+declare module 'view' {
+  interface ViewContext {
+    thumbnails?: ThumbnailViewContext;
+  }
+}
+
 @customElement('frigate-card-surround-thumbnails')
 export class FrigateCardSurround extends LitElement {
   @property({ attribute: false })
@@ -64,7 +75,8 @@ export class FrigateCardSurround extends LitElement {
       !this.config ||
       this.config.mode === 'none' ||
       this.view.target ||
-      !this.browseMediaParams
+      !this.browseMediaParams ||
+      !(this.view.context?.thumbnails?.fetch ?? true)
     ) {
       return;
     }
@@ -147,7 +159,7 @@ export class FrigateCardSurround extends LitElement {
             .target=${this.view.target}
             .selected=${this.view.childIndex}
             .cameras=${this.cameras}
-            @frigate-card:change-view=${(ev: CustomEvent) => changeDrawer(ev, 'close')}
+            @frigate-card:view:change=${(ev: CustomEvent) => changeDrawer(ev, 'close')}
             @frigate-card:thumbnail-carousel:tap=${(ev: CustomEvent<ThumbnailCarouselTap>) => {
               // Send the view change from the source of the tap event, so the
               // view change will be caught by the handler above (to close the drawer).

--- a/src/components/thumbnail.ts
+++ b/src/components/thumbnail.ts
@@ -282,8 +282,8 @@ export class FrigateCardThumbnail extends LitElement {
                   view: 'timeline',
                   target: this.target,
                   childIndex: this.childIndex ?? null,
-                  context: {},
                 })
+                .removeContext('timeline')
                 .dispatchChangeEvent(this);
             } else if (recording) {
               this.view
@@ -291,7 +291,9 @@ export class FrigateCardThumbnail extends LitElement {
                   view: 'timeline',
                   target: null,
                   childIndex: null,
-                  context: {
+                })
+                .mergeInContext({
+                  timeline: {
                     window: {
                       start: fromUnixTime(recording.start_time),
                       end: fromUnixTime(recording.end_time),

--- a/src/components/timeline.ts
+++ b/src/components/timeline.ts
@@ -83,11 +83,11 @@ interface FrigateCardTimelineItem extends TimelineItem {
 }
 
 interface TimelineViewContext {
-   // The selected timeline window.
-   window?: TimelineWindow;
+  // The selected timeline window.
+  window?: TimelineWindow;
 
-   // The date of the last event fetch.
-   dateFetch?: Date;
+  // The date of the last event fetch.
+  dateFetch?: Date;
 }
 
 declare module 'view' {

--- a/src/components/viewer.ts
+++ b/src/components/viewer.ts
@@ -618,7 +618,7 @@ export class FrigateCardViewerCarousel extends LitElement {
       .label="${this.view.media.title}"
       .titlePopupConfig=${this.viewerConfig?.controls.title}
       transitionEffect=${this._getTransitionEffect()}
-      @frigate-card:carousel:select=${this._setViewHandler.bind(this)}
+      @frigate-card:media-carousel:select=${this._setViewHandler.bind(this)}
       @frigate-card:media-show=${this._recordingSeekHandler.bind(this)}
     >
       <frigate-card-next-previous-control

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,7 +1,6 @@
 declare module '*.scss';
 declare module '*.jpg';
-declare module "view" {
+declare module 'view' {
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
-  interface ViewContext {
-  }
+  interface ViewContext {}
 }

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,2 +1,7 @@
 declare module '*.scss';
 declare module '*.jpg';
+declare module "view" {
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  interface ViewContext {
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -485,6 +485,7 @@ const frigateCardConditionSchema = z.object({
   view: z.string().array().optional(),
   fullscreen: z.boolean().optional(),
   camera: z.string().array().optional(),
+  mediaLoaded: z.boolean().optional(),
   state: stateConditions.optional(),
 });
 export type FrigateCardCondition = z.infer<typeof frigateCardConditionSchema>;


### PR DESCRIPTION
* Closes #758 
* Changes previous behavior of hiding elements when messages are being disabled, as this new functionality allows users to opt into very similar behavior.

**Example:** Only show the arrow when media has been loaded (not during loading, and not on top of error messages, etc).

```yaml
elements:
  - type: custom:frigate-card-conditional
    conditions:
      mediaLoaded: true
    elements:
      - type: icon
        icon: mdi:arrow-up
        style:
          background: rgba(255, 255, 255, 0.25)
          border-radius: 5px
          right: 25px
          top: 25px
          color: red
```