### PR TITLE
Update homeAssistantWSRequest to accept passthrough JSON

### DIFF
--- a/src/utils/frigate.ts
+++ b/src/utils/frigate.ts
@@ -77,7 +77,8 @@ export const getRecordingsSummary = async (
       type: "frigate/recordings/summary",
       instance_id: client_id,
       camera: camera_name
-    }
+    },
+    true,
   );
 };
 
@@ -106,7 +107,8 @@ export const getRecordingSegments = async (
       camera: camera_name,
       before: Math.floor(before.getTime() / 1000),
       after: Math.ceil(after.getTime() / 1000),
-    }
+    },
+    true,
   );
 };
 
@@ -133,6 +135,7 @@ export async function retainEvent(
     hass,
     retainResultSchema,
     retainRequest,
+    true,
   );
   if (!response.success) {
     throw new FrigateCardError(localize('error.failed_retain'), {

--- a/src/utils/ha/index.ts
+++ b/src/utils/ha/index.ts
@@ -25,6 +25,7 @@ export async function homeAssistantWSRequest<T>(
   hass: HomeAssistant,
   schema: ZodSchema<T>,
   request: MessageBase,
+  passthrough = false,
 ): Promise<T> {
   let response;
   try {
@@ -44,7 +45,11 @@ export async function homeAssistantWSRequest<T>(
       request: request,
     });
   }
-  const parseResult = schema.safeParse(response);
+  // Some endpoints on the integration pass through JSON directly from Frigate
+  // These end up wrapped in a string and must be unwrapped first
+  const parseResult = passthrough
+    ? schema.safeParse(JSON.parse(response))
+    : schema.safeParse(response);
   if (!parseResult.success) {
     throw new FrigateCardError(localize('error.invalid_response'), {
       request: request,


### PR DESCRIPTION
With https://github.com/blakeblackshear/frigate-hass-integration/pull/321, the JSON endpoints that come directly from Frigate but get passed through the websocket end up wrapped in a string. This PR allows the card to decode them properly while allowing the core to avoid doing unnecessary work.