### PR TITLE
Allow configuration of hover style for Frigate card custom elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,16 +798,39 @@ elements to add special Frigate card functionality.
 
 | Element name | Description                                         |
 | ------------- | --------------------------------------------- |
-| `custom:frigate-card-menu-icon` | Add an arbitrary icon to the Frigate Card menu. Configuration is ~identical to that of the [Picture Elements Icon](https://www.home-assistant.io/lovelace/picture-elements/#icon-element) except with a type name of `custom:frigate-card-menu-icon`.|
-| `custom:frigate-card-menu-state-icon` | Add a state icon to the Frigate Card menu that represents the state of a Home Assistant entity. Configuration is ~identical to that of the [Picture Elements State Icon](https://www.home-assistant.io/lovelace/picture-elements/#state-icon) except with a type name of `custom:frigate-card-menu-state-icon`.|
+| `custom:frigate-card-menu-icon` | Add an arbitrary icon to the Frigate Card menu. See [configuration below](#frigate-card-menu-icon). |
+| `custom:frigate-card-menu-state-icon` | Add a state icon to the Frigate Card menu that represents the state of a Home Assistant entity. See [configuration below](#frigate-card-menu-state-icon). |
 | `custom:frigate-card-menu-submenu` | Add a configurable submenu dropdown. See [configuration below](#frigate-card-menu-submenu).|
 | `custom:frigate-card-menu-submenu-select` | Add a submenu based on a `select` or `input_select`. See [configuration below](#frigate-card-submenu-select).|
 | `custom:frigate-card-conditional` | Restrict a set of elements to only render when the card is showing particular a particular [view](#views). See [configuration below](#frigate-card-conditional).|
 
-
 **Note**: ℹ️ Manual positioning of custom menu icons or submenus via the `style`
 parameter is not supported as the menu buttons displayed are context sensitive
 so manual positioning by the user is not feasible.
+
+**Note**: ℹ️ Support for special style on hover (`style:hover`) is only possible on the certain custom Frigate elements (and specifically not on stock picture elements, which are rendered by the Home Assistant frontend code).
+
+<a name="frigate-card-menu-icon"></a>
+
+#### `custom:frigate-card-menu-icon`
+
+Parameters for the `custom:frigate-card-menu-icon` element are identical to the parameters of the [stock Home Assistant Icon Element](https://www.home-assistant.io/lovelace/picture-elements/#icon-element) with the exception of these parameters which differ:
+
+| Parameter | Description |
+| - | - |
+| `type` | Must be `custom:frigate-card-menu-icon`. |
+| `style:hover` | Position and style the element during hover using CSS. |
+
+<a name="frigate-card-menu-state-icon"></a>
+
+#### `custom:frigate-card-menu-state-icon`
+
+Parameters for the `custom:frigate-card-menu-icon` element are identical to the parameters of the [stock Home Assistant State Icon Element](https://www.home-assistant.io/lovelace/picture-elements/#state-icon) with the exception of these parameters which differ:
+
+| Parameter | Description |
+| - | - |
+| `type` | Must be `custom:frigate-card-menu-state-icon`. |
+| `style:hover` | Position and style the element during hover using CSS. |
 
 <a name="frigate-card-submenu"></a>
 
@@ -818,6 +841,7 @@ Parameters for the `custom:frigate-card-menu-submenu` element are identical to t
 | Parameter | Description |
 | - | - |
 | `type` | Must be `custom:frigate-card-menu-submenu`. |
+| `style:hover` | Position and style the element during hover using CSS. |
 | `items` | A list of menu items, as described below. |
 
 <a name="frigate-card-submenu-items"></a>
@@ -833,6 +857,7 @@ Parameters for the `custom:frigate-card-menu-submenu` element are identical to t
 | `selected` | `false` | Whether or not to show this item as selected. |
 | `enabled` | `true` | Whether or not to show this item as enabled / selectable. |
 | `style` | | Position and style the element using CSS. |
+| `style:hover` | | Position and style the element during hover using CSS. |
 | `tap_action`, `double_tap_action`, `hold_action`, `start_tap`, `end_tap` | | [Home Assistant action configuration](https://www.home-assistant.io/lovelace/actions) including the extended functionality described under [actions](#actions). |
 
 See the [Configuring a Submenu example](#configuring-a-submenu-example).
@@ -848,6 +873,7 @@ Parameters for the `custom:frigate-card-menu-submenu-select` element are identic
 | Parameter | Description |
 | - | - |
 | `type` | Must be `custom:frigate-card-menu-submenu-select`. |
+| `style:hover` | Position and style the element during hover using CSS. |
 | `options` | An optional dictionary of overrides keyed by the option name that the given select entity supports. These options can be used to set or override submenu item parameters on a per-option basis. The format is as described in [Submenu Items](#frigate-card-submenu-items) above.|
 
 See the [Configuring a Select Submenu example](#configuring-a-select-submenu-example).
@@ -885,7 +911,6 @@ Parameters for the `custom:frigate-card-conditional` element:
 |`camera_select`|Select a given camera. Takes a single additional `camera` parameter with the [camera ID](#camera-ids) of the camera to select. Respects the value of `view.camera_select` to choose the appropriate view on the new camera.|
 |`menu_toggle` | Show/hide the menu (for the `hidden` mode style). |
 |`media_player`| Perform a media player action. Takes a `media_player` parameter with the entity ID of the media_player on which to perform the action, and a `media_player_action` parameter which should be either `play` or `stop` to play or stop the media in question. |
-
 
 <a name="views"></a>
 
@@ -1614,35 +1639,67 @@ elements:
   - type: custom:frigate-card-menu-icon
     icon: mdi:car
     title: Vroom
+    style:
+      color: white
+    style:hover:
+      color: red
   - type: custom:frigate-card-menu-state-icon
     entity: light.office_main_lights
     title: Office lights
     icon: mdi:chair-rolling
     state_color: true
+    style:
+      color: white
+    style:hover:
+      color: red
   - type: custom:frigate-card-menu-submenu
     icon: mdi:menu
+    style:
+      color: white
+    style:hover:
+      color: red
     items:
       - title: Lights
         icon: mdi:lightbulb
         entity: light.office_main_lights
         tap_action:
           action: toggle
+        style:
+          color: white
+        style:hover:
+          color: red
       - title: Google
         icon: mdi:google
         enabled: false
         tap_action:
           action: url
           url_path: https://www.google.com
+        style:
+          color: white
+        style:hover:
+          color: red
   - type: custom:frigate-card-menu-submenu-select
     icon: mdi:lamps
     entity: input_select.kitchen_scene
+    style:
+      color: white
+    style:hover:
+      color: red
     options:
       scene.kitchen_cooking_scene:
         icon: mdi:chef-hat
         title: Cooking time!
+        style:
+          color: white
+        style:hover:
+          color: red
       scene.kitchen_tv_scene:
         icon: mdi:television
         title: TV!
+        style:
+          color: white
+        style:hover:
+          color: red
     # Show a pig icon if the card is in the live view, in fullscreen mode, light.office_main_lights is on and the media has been loaded.
   - type: custom:frigate-card-conditional
     elements:

--- a/src/card.ts
+++ b/src/card.ts
@@ -211,6 +211,11 @@ export class FrigateCard extends LitElement {
   protected _triggers: Map<string, Date> = new Map();
   protected _untriggerTimerID: number | null = null;
 
+  // The style of emphasized menu items.
+  protected static _emphasizedButtonStyle: StyleInfo = {
+    color: 'var(--primary-color, white)',
+  };
+
   /**
    * Set the Home Assistant object.
    */
@@ -307,16 +312,6 @@ export class FrigateCard extends LitElement {
   }
 
   /**
-   * Get the style of emphasized menu items.
-   * @returns A StyleInfo.
-   */
-  protected _getEmphasizedStyle(): StyleInfo {
-    return {
-      color: 'var(--primary-color, white)',
-    };
-  }
-
-  /**
    * Given a button determine if the style should be emphasized by examining all
    * of the actions sequentially.
    * @param button The button to examine.
@@ -356,7 +351,7 @@ export class FrigateCard extends LitElement {
           (frigateCardAction.frigate_card_action === 'camera_select' &&
             this._view?.camera === frigateCardAction.camera)
         ) {
-          return this._getEmphasizedStyle();
+          return FrigateCard._emphasizedButtonStyle;
         }
       }
     }
@@ -415,7 +410,7 @@ export class FrigateCard extends LitElement {
       ...this._getConfig().menu.buttons.live,
       type: 'custom:frigate-card-menu-icon',
       title: localize('config.view.views.live'),
-      style: this._view?.is('live') ? this._getEmphasizedStyle() : {},
+      style: this._view?.is('live') ? FrigateCard._emphasizedButtonStyle : {},
       tap_action: createFrigateCardCustomAction('live') as FrigateCardCustomAction,
     });
 
@@ -434,7 +429,7 @@ export class FrigateCard extends LitElement {
         ...this._getConfig().menu.buttons.clips,
         type: 'custom:frigate-card-menu-icon',
         title: localize('config.view.views.clips'),
-        style: this._view?.is('clips') ? this._getEmphasizedStyle() : {},
+        style: this._view?.is('clips') ? FrigateCard._emphasizedButtonStyle : {},
         tap_action: createFrigateCardCustomAction('clips') as FrigateCardCustomAction,
         hold_action: createFrigateCardCustomAction('clip') as FrigateCardCustomAction,
       });
@@ -453,7 +448,7 @@ export class FrigateCard extends LitElement {
         ...this._getConfig().menu.buttons.snapshots,
         type: 'custom:frigate-card-menu-icon',
         title: localize('config.view.views.snapshots'),
-        style: this._view?.is('snapshots') ? this._getEmphasizedStyle() : {},
+        style: this._view?.is('snapshots') ? FrigateCard._emphasizedButtonStyle : {},
         tap_action: createFrigateCardCustomAction(
           'snapshots',
         ) as FrigateCardCustomAction,
@@ -468,7 +463,7 @@ export class FrigateCard extends LitElement {
       ...this._getConfig().menu.buttons.image,
       type: 'custom:frigate-card-menu-icon',
       title: localize('config.view.views.image'),
-      style: this._view?.is('image') ? this._getEmphasizedStyle() : {},
+      style: this._view?.is('image') ? FrigateCard._emphasizedButtonStyle : {},
       tap_action: createFrigateCardCustomAction('image') as FrigateCardCustomAction,
     });
 
@@ -486,7 +481,7 @@ export class FrigateCard extends LitElement {
         ...this._getConfig().menu.buttons.timeline,
         type: 'custom:frigate-card-menu-icon',
         title: localize('config.view.views.timeline'),
-        style: this._view?.is('timeline') ? this._getEmphasizedStyle() : {},
+        style: this._view?.is('timeline') ? FrigateCard._emphasizedButtonStyle : {},
         tap_action: createFrigateCardCustomAction('timeline') as FrigateCardCustomAction,
       });
     }
@@ -525,7 +520,7 @@ export class FrigateCard extends LitElement {
         tap_action: createFrigateCardCustomAction(
           'fullscreen',
         ) as FrigateCardCustomAction,
-        style: screenfull.isFullscreen ? this._getEmphasizedStyle() : {},
+        style: screenfull.isFullscreen ? FrigateCard._emphasizedButtonStyle : {},
       });
     }
 

--- a/src/components/hover-styler.ts
+++ b/src/components/hover-styler.ts
@@ -1,49 +1,107 @@
-import { html, LitElement, TemplateResult } from 'lit';
+import { html, LitElement, PropertyValues, TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import { createRef, ref, Ref } from 'lit/directives/ref.js';
 import { StyleInfo } from 'lit/directives/style-map.js';
+import { merge } from 'lodash-es';
+import { contentsChanged } from '../utils/basic';
 
 // This component exists to allow user-provided styles to applied dynamically on
-// hover (inline styling does not support hover by default, so this component
-// attempts to mimic it).
+// hover. This is implemented this way because:
+// - Inline styling does not support hover (i.e. dynamic hover styles cannot be
+//   set directly on an element).
+// - In some cases we may wish to apply styles selectively further "down the
+//   DOM" (e.g. styling an mwc-list-item during hover will require styling the
+//   child elements to override their set styles -- CSS style inheritance will
+//   not work in these cases).
 
 @customElement('frigate-card-hover-styler')
 export class FrigateCardHoverStyle extends LitElement {
-  @property({ attribute: false })
-  public nonHoverStyle?: StyleInfo;
+  // Use contentsChanged here since the menu dynamically refreshes its state
+  // (e.g. icons, colors) and that causes the object for the style to change
+  // continuously even though the contents won't.
+  @property({ attribute: false, hasChanged: contentsChanged })
+  public baseStyle?: StyleInfo;
 
-  @property({ attribute: false })
+  @property({ attribute: false, hasChanged: contentsChanged })
   public hoverStyle?: StyleInfo;
 
+  @property({ attribute: false })
+  public selector?: string;
+
+  protected _refSlot: Ref<HTMLSlotElement> = createRef();
+
+  protected _baseStyle?: string;
+  protected _hoverStyle?: string;
+
   protected _styleInfoToString(styleInfo: StyleInfo): string {
-    // StyleMap() cannot be used directly as it raises an exception if it's not
+    // styleMap() cannot be used directly as it raises an exception if it's not
     // used on the style attribute directly, so do the conversion manually:
     // Inspired by lit-html:
     // https://github.com/lit/lit/blob/main/packages/lit-html/src/directives/style-map.ts#L45
     return Object.keys(styleInfo).reduce((style, prop) => {
       const value: string | null | undefined = styleInfo[prop]
-        ?.trim()
-        .replace(/;+$/, '');
+        ?.trim();
       if (value === null || value === undefined) {
         return style;
       }
       prop = prop.replace(/(?:^(webkit|moz|ms|o)|)(?=[A-Z])/g, '-$&').toLowerCase();
-
-      // All styles need to be mandatorily applied in order to have the same or
-      // greater precedence as inline styling on the element which this
-      // component is intended as a replacement for.
-      const alreadyImportant = value.endsWith('!important');
-      return style + `${prop}:${value} ${alreadyImportant ? '' : '!important'};`;
+      return style + `${prop}:${value};`;
     }, '');
   }
 
+  /**
+   * Called before each update.
+   */
+  protected willUpdate(changedProps: PropertyValues): void {
+    if (changedProps.has('baseStyle')) {
+      this._baseStyle = this._styleInfoToString(this.baseStyle ?? {});
+    }
+    if (changedProps.has('baseStyle') || changedProps.has('hoverStyle')) {
+      const mergedHoverStyle = {};
+      merge(mergedHoverStyle, this.baseStyle ?? {}, this.hoverStyle ?? {});
+      this._hoverStyle = this._styleInfoToString(mergedHoverStyle);
+    }
+  }
+
+  /**
+   * Called before each update.
+   */
+  protected updated(): void {
+    this._applyStyle(false);
+  }
+
+  /**
+   * Apply the relevant styles.
+   * @param hover Whether to apply the hover style.
+   */
+  protected _applyStyle(hover: boolean): void {
+    const slottedElements = this._refSlot.value?.assignedElements({ flatten: true });
+    if (!slottedElements) {
+      return;
+    }
+
+    let targetElements: Element[] = [];
+    if (this.selector) {
+      for (const slottedElement of slottedElements) {
+        targetElements.push(...slottedElement.querySelectorAll(this.selector));
+      }
+    } else {
+      targetElements = slottedElements;
+    }
+
+    targetElements.forEach((element) => {
+      element.setAttribute('style', (hover ? this._hoverStyle : this._baseStyle) ?? '');
+    });
+  }
+
   public render(): TemplateResult {
-    // This is not especially performant. See:
-    // https://lit.dev/docs/components/styles/#style-element
-    return html` <style>
-        ::slotted(*) { ${this._styleInfoToString(this.nonHoverStyle ?? {})} }
-        ::slotted(*:hover) { ${this._styleInfoToString(this.hoverStyle ?? {})} }
-      </style>
-      <slot></slot>`;
+    return html` <slot
+      ${ref(this._refSlot)}
+      @mouseover=${() => this._applyStyle(true)}
+      @mouseout=${() => this._applyStyle(false)}
+      @slotchange=${() => this._applyStyle(false)}
+    >
+    </slot>`;
   }
 }
 

--- a/src/components/hover-styler.ts
+++ b/src/components/hover-styler.ts
@@ -1,0 +1,54 @@
+import { html, LitElement, TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { StyleInfo } from 'lit/directives/style-map.js';
+
+// This component exists to allow user-provided styles to applied dynamically on
+// hover (inline styling does not support hover by default, so this component
+// attempts to mimic it).
+
+@customElement('frigate-card-hover-styler')
+export class FrigateCardHoverStyle extends LitElement {
+  @property({ attribute: false })
+  public nonHoverStyle?: StyleInfo;
+
+  @property({ attribute: false })
+  public hoverStyle?: StyleInfo;
+
+  protected _styleInfoToString(styleInfo: StyleInfo): string {
+    // StyleMap() cannot be used directly as it raises an exception if it's not
+    // used on the style attribute directly, so do the conversion manually:
+    // Inspired by lit-html:
+    // https://github.com/lit/lit/blob/main/packages/lit-html/src/directives/style-map.ts#L45
+    return Object.keys(styleInfo).reduce((style, prop) => {
+      const value: string | null | undefined = styleInfo[prop]
+        ?.trim()
+        .replace(/;+$/, '');
+      if (value === null || value === undefined) {
+        return style;
+      }
+      prop = prop.replace(/(?:^(webkit|moz|ms|o)|)(?=[A-Z])/g, '-$&').toLowerCase();
+
+      // All styles need to be mandatorily applied in order to have the same or
+      // greater precedence as inline styling on the element which this
+      // component is intended as a replacement for.
+      const alreadyImportant = value.endsWith('!important');
+      return style + `${prop}:${value} ${alreadyImportant ? '' : '!important'};`;
+    }, '');
+  }
+
+  public render(): TemplateResult {
+    // This is not especially performant. See:
+    // https://lit.dev/docs/components/styles/#style-element
+    return html` <style>
+        ::slotted(*) { ${this._styleInfoToString(this.nonHoverStyle ?? {})} }
+        ::slotted(*:hover) { ${this._styleInfoToString(this.hoverStyle ?? {})} }
+      </style>
+      <slot></slot>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'frigate-card-hover-styler': FrigateCardHoverStyle;
+  }
+}

--- a/src/components/menu.ts
+++ b/src/components/menu.ts
@@ -274,7 +274,7 @@ export class FrigateCardMenu extends LitElement {
     //   (`data-state`). This looks up a CSS style in `menu.scss`.
 
     return html` <frigate-card-hover-styler
-      .nonHoverStyle=${stateParameters['style']}
+      .baseStyle=${stateParameters['style']}
       .hoverStyle=${stateParameters['style:hover']}
     >
       <ha-icon-button

--- a/src/components/menu.ts
+++ b/src/components/menu.ts
@@ -5,7 +5,7 @@ import {
   LitElement,
   PropertyValues,
   TemplateResult,
-  unsafeCSS
+  unsafeCSS,
 } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
@@ -19,17 +19,18 @@ import type {
   MenuButton,
   MenuConfig,
   MenuItem,
-  StateParameters
+  StateParameters,
 } from '../types.js';
 import {
   convertActionToFrigateCardCustomAction,
   frigateCardHandleActionConfig,
   frigateCardHasAction,
-  getActionConfigGivenAction
+  getActionConfigGivenAction,
 } from '../utils/action.js';
 import { FRIGATE_ICON_SVG_PATH } from '../utils/frigate.js';
 import { refreshDynamicStateParameters } from '../utils/ha';
 import './submenu.js';
+import './hover-styler.js';
 
 export const FRIGATE_BUTTON_MENU_ICON = 'frigate';
 
@@ -272,24 +273,28 @@ export class FrigateCardMenu extends LitElement {
     // - Static styling based on domain (`data-domain`) and state
     //   (`data-state`). This looks up a CSS style in `menu.scss`.
 
-    return html` <ha-icon-button
-      data-domain=${ifDefined(stateParameters.data_domain)}
-      data-state=${ifDefined(stateParameters.data_state)}
-      class="${classMap(classes)}"
-      style="${styleMap(stateParameters.style || {})}"
-      .actionHandler=${actionHandler({
-        hasHold: hasHold,
-        hasDoubleClick: hasDoubleClick,
-      })}
-      .label=${stateParameters.title || ''}
-      @action=${(ev) => this._actionHandler(ev, button)}
+    return html` <frigate-card-hover-styler
+      .nonHoverStyle=${stateParameters['style']}
+      .hoverStyle=${stateParameters['style:hover']}
     >
-      ${svgPath
-        ? html`<ha-svg-icon .path="${svgPath}"></ha-svg-icon>`
-        : html`<ha-icon
-            icon="${stateParameters.icon || 'mdi:gesture-tap-button'}"
-          ></ha-icon>`}
-    </ha-icon-button>`;
+      <ha-icon-button
+        data-domain=${ifDefined(stateParameters.data_domain)}
+        data-state=${ifDefined(stateParameters.data_state)}
+        class="${classMap(classes)}"
+        .actionHandler=${actionHandler({
+          hasHold: hasHold,
+          hasDoubleClick: hasDoubleClick,
+        })}
+        .label=${stateParameters.title || ''}
+        @action=${(ev) => this._actionHandler(ev, button)}
+      >
+        ${svgPath
+          ? html`<ha-svg-icon .path="${svgPath}"></ha-svg-icon>`
+          : html`<ha-icon
+              icon="${stateParameters.icon || 'mdi:gesture-tap-button'}"
+            ></ha-icon>`}
+      </ha-icon-button>
+    </frigate-card-hover-styler>`;
   }
 
   /**
@@ -342,7 +347,7 @@ export class FrigateCardMenu extends LitElement {
 }
 
 declare global {
-	interface HTMLElementTagNameMap {
-		"frigate-card-menu": FrigateCardMenu
-	}
+  interface HTMLElementTagNameMap {
+    'frigate-card-menu': FrigateCardMenu;
+  }
 }

--- a/src/components/submenu.ts
+++ b/src/components/submenu.ts
@@ -9,7 +9,6 @@ import {
 } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { styleMap } from 'lit/directives/style-map.js';
 import { actionHandler } from '../action-handler-directive.js';
 import submenuStyle from '../scss/submenu.scss';
 import {
@@ -24,6 +23,7 @@ import {
 } from '../utils/action.js';
 import { isHassDifferent, refreshDynamicStateParameters } from '../utils/ha';
 import { domainIcon } from '../utils/icons/domain-icon.js';
+import './hover-styler.js';
 
 @customElement('frigate-card-submenu')
 export class FrigateCardSubmenu extends LitElement {
@@ -41,7 +41,6 @@ export class FrigateCardSubmenu extends LitElement {
     const getIcon = (stateParameters: StateParameters): TemplateResult => {
       if (stateParameters.icon) {
         return html` <ha-icon
-          style="${styleMap(stateParameters.style || {})}"
           data-domain=${ifDefined(stateParameters.data_domain)}
           data-state=${ifDefined(stateParameters.data_state)}
           slot="graphic"
@@ -53,27 +52,32 @@ export class FrigateCardSubmenu extends LitElement {
     };
 
     return html`
-      <mwc-list-item
-        style="${styleMap(stateParameters.style || {})}"
-        graphic=${ifDefined(stateParameters.icon ? 'icon' : undefined)}
-        ?twoline=${!!item.subtitle}
-        ?selected=${item.selected}
-        ?activated=${item.selected}
-        ?disabled=${item.enabled === false}
-        aria-label="${stateParameters.title || ''}"
-        @action=${(ev) => {
-          // Attach the action config so ascendants have access to it.
-          ev.detail.config = item;
-        }}
-        .actionHandler=${actionHandler({
-          hasHold: frigateCardHasAction(item.hold_action),
-          hasDoubleClick: frigateCardHasAction(item.double_tap_action),
-        })}
+      <frigate-card-hover-styler
+        .baseStyle=${stateParameters.style}
+        .hoverStyle=${stateParameters['style:hover']}
+        .selector=${'mwc-list-item *'}
       >
-        <span>${stateParameters.title || ''}</span>
-        ${item.subtitle ? html`<span slot="secondary">${item.subtitle}</span>` : ''}
-        ${getIcon(stateParameters)}
-      </mwc-list-item>
+        <mwc-list-item
+          graphic=${ifDefined(stateParameters.icon ? 'icon' : undefined)}
+          ?twoline=${!!item.subtitle}
+          ?selected=${item.selected}
+          ?activated=${item.selected}
+          ?disabled=${item.enabled === false}
+          aria-label="${stateParameters.title || ''}"
+          @action=${(ev) => {
+            // Attach the action config so ascendants have access to it.
+            ev.detail.config = item;
+          }}
+          .actionHandler=${actionHandler({
+            hasHold: frigateCardHasAction(item.hold_action),
+            hasDoubleClick: frigateCardHasAction(item.double_tap_action),
+          })}
+        >
+          <span>${stateParameters.title || ''}</span>
+          ${item.subtitle ? html`<span slot="secondary">${item.subtitle}</span>` : ''}
+          ${getIcon(stateParameters)}
+        </mwc-list-item>
+      </frigate-card-hover-styler>
     `;
   }
 
@@ -92,23 +96,27 @@ export class FrigateCardSubmenu extends LitElement {
         }
         @click=${(ev) => stopEventFromActivatingCardWideActions(ev)}
       >
-        <ha-icon-button
-          style="${styleMap(this.submenu.style || {})}"
-          class="button"
+        <frigate-card-hover-styler
+          .baseStyle=${this.submenu.style}
+          .hoverStyle=${this.submenu['style:hover']}
           slot="trigger"
-          .label=${this.submenu.title || ''}
-          .actionHandler=${actionHandler({
-            // Need to allow event to propagate upwards, as it's caught by the
-            // <ha-button-menu> trigger slot to open/close the menu. Further
-            // propagation is forbidden by the @click handler on
-            // <ha-button-menu>.
-            allowPropagation: true,
-            hasHold: frigateCardHasAction(this.submenu.hold_action),
-            hasDoubleClick: frigateCardHasAction(this.submenu.double_tap_action),
-          })}
         >
-          <ha-icon icon="${this.submenu.icon}"></ha-icon>
-        </ha-icon-button>
+          <ha-icon-button
+            class="button"
+            .label=${this.submenu.title || ''}
+            .actionHandler=${actionHandler({
+              // Need to allow event to propagate upwards, as it's caught by the
+              // <ha-button-menu> trigger slot to open/close the menu. Further
+              // propagation is forbidden by the @click handler on
+              // <ha-button-menu>.
+              allowPropagation: true,
+              hasHold: frigateCardHasAction(this.submenu.hold_action),
+              hasDoubleClick: frigateCardHasAction(this.submenu.double_tap_action),
+            })}
+          >
+            <ha-icon icon="${this.submenu.icon}"></ha-icon>
+          </ha-icon-button>
+        </frigate-card-hover-styler>
         ${this.submenu.items.map(this._renderItem.bind(this))}
       </ha-button-menu>
     `;

--- a/src/scss/button.scss
+++ b/src/scss/button.scss
@@ -8,6 +8,12 @@ ha-icon-button.button {
   /* Buttons can always be clicked */
   pointer-events: auto;
   opacity: 0.9;
+
+  transition: opacity 0.2s linear;
+}
+
+ha-icon-button.button:hover {
+  opacity: 1.0;
 }
 
 // =====================================================================================

--- a/src/types.ts
+++ b/src/types.ts
@@ -267,6 +267,7 @@ const actionsSchema = z.object({
 
 const elementsBaseSchema = actionsBaseSchema.extend({
   style: z.object({}).passthrough().optional(),
+  'style:hover': z.object({}).passthrough().optional(),
   title: z.string().nullable().optional(),
 });
 
@@ -1259,6 +1260,7 @@ export interface StateParameters {
   title?: string | null;
   state_color?: boolean;
   style?: StyleInfo;
+  'style:hover'?: StyleInfo;
   data_domain?: string;
   data_state?: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -267,7 +267,6 @@ const actionsSchema = z.object({
 
 const elementsBaseSchema = actionsBaseSchema.extend({
   style: z.object({}).passthrough().optional(),
-  'style:hover': z.object({}).passthrough().optional(),
   title: z.string().nullable().optional(),
 });
 
@@ -447,12 +446,20 @@ const menuBaseSchema = z.object({
   icon: z.string().optional(),
 });
 
-export const menuIconSchema = menuBaseSchema.merge(iconSchema).extend({
-  type: z.literal('custom:frigate-card-menu-icon'),
+const frigateCardVisualBaseSchema = z.object({
+  'style:hover': z.object({}).passthrough().optional(),
 });
+
+export const menuIconSchema = menuBaseSchema
+  .merge(frigateCardVisualBaseSchema)
+  .merge(iconSchema)
+  .extend({
+    type: z.literal('custom:frigate-card-menu-icon'),
+  });
 export type MenuIcon = z.infer<typeof menuIconSchema>;
 
 export const menuStateIconSchema = menuBaseSchema
+  .merge(frigateCardVisualBaseSchema)
   .merge(stateIconSchema)
   .extend({
     type: z.literal('custom:frigate-card-menu-state-icon'),
@@ -460,26 +467,34 @@ export const menuStateIconSchema = menuBaseSchema
   .merge(menuBaseSchema);
 export type MenuStateIcon = z.infer<typeof menuStateIconSchema>;
 
-const menuSubmenuItemSchema = elementsBaseSchema.extend({
-  entity: z.string().optional(),
-  icon: z.string().optional(),
-  state_color: z.boolean().default(true),
-  selected: z.boolean().default(false),
-  subtitle: z.string().optional(),
-  enabled: z.boolean().default(true),
-});
+const menuSubmenuItemSchema = elementsBaseSchema
+  .merge(frigateCardVisualBaseSchema)
+  .extend({
+    entity: z.string().optional(),
+    icon: z.string().optional(),
+    state_color: z.boolean().default(true),
+    selected: z.boolean().default(false),
+    subtitle: z.string().optional(),
+    enabled: z.boolean().default(true),
+  });
 export type MenuSubmenuItem = z.infer<typeof menuSubmenuItemSchema>;
 
-const menuSubmenuSchema = menuBaseSchema.merge(iconSchema).extend({
-  type: z.literal('custom:frigate-card-menu-submenu'),
-  items: menuSubmenuItemSchema.array(),
-});
+const menuSubmenuSchema = menuBaseSchema
+  .merge(frigateCardVisualBaseSchema)
+  .merge(iconSchema)
+  .extend({
+    type: z.literal('custom:frigate-card-menu-submenu'),
+    items: menuSubmenuItemSchema.array(),
+  });
 export type MenuSubmenu = z.infer<typeof menuSubmenuSchema>;
 
-const menuSubmenuSelectSchema = menuBaseSchema.merge(stateIconSchema).extend({
-  type: z.literal('custom:frigate-card-menu-submenu-select'),
-  options: z.record(menuSubmenuItemSchema.deepPartial()).optional(),
-});
+const menuSubmenuSelectSchema = menuBaseSchema
+  .merge(frigateCardVisualBaseSchema)
+  .merge(stateIconSchema)
+  .extend({
+    type: z.literal('custom:frigate-card-menu-submenu-select'),
+    options: z.record(menuSubmenuItemSchema.deepPartial()).optional(),
+  });
 export type MenuSubmenuSelect = z.infer<typeof menuSubmenuSelectSchema>;
 
 export type MenuItem = MenuIcon | MenuStateIcon | MenuSubmenu | MenuSubmenuSelect;
@@ -527,10 +542,12 @@ export type PictureElements = z.infer<typeof pictureElementsSchema>;
  */
 const mediaLayoutConfigSchema = z.object({
   fit: z.enum(['contain', 'cover', 'fill']).optional(),
-  position: z.object({
-    x: z.number().min(0).max(100).optional(),
-    y: z.number().min(0).max(100).optional(),
-  }).optional(),
+  position: z
+    .object({
+      x: z.number().min(0).max(100).optional(),
+      y: z.number().min(0).max(100).optional(),
+    })
+    .optional(),
 });
 export type MediaLayoutConfig = z.infer<typeof mediaLayoutConfigSchema>;
 


### PR DESCRIPTION
* Closes #797 

Example usage:

```yaml
elements:
  - type: custom:frigate-card-menu-icon
    icon: mdi:car
    style:
      color: red
    style:hover:
      color: green
```

@felipecrs This PR will do what is discussed in #797 -- but honestly, is it that useful? Keep in mind this can only work on Frigate card custom elements (not stock elements), which right now means only icons/submenus added to the menu. And in those cases, is the user likely to want to do something funky when one button hovers but not them all? As new custom visual elements are added (e.g. #798) though, I could see this being more useful.

Thoughts?