### PR TITLE
Use lodash cloneDeep and generate facade chunk

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -65,7 +65,12 @@ const plugins = [
  */
 const config = {
   input: 'src/card.ts',
-  preserveEntrySignatures: false,
+  // Specifically want a facade created as HACS will attach a hacstag
+  // queryparameter to the resource. Without a facade when chunks re-import the
+  // card chunk, they'll refer to a 'different' copy of the card chunk without
+  // the hacstag, causing a re-download of the same content and functionality
+  // problems.
+  preserveEntrySignatures: 'strict',
   output: {
     entryFileNames: 'frigate-hass-card.js',
     dir: 'dist',

--- a/src/card-condition.ts
+++ b/src/card-condition.ts
@@ -5,6 +5,7 @@ import type {
 } from './types';
 import { HassEntities } from 'home-assistant-js-websocket';
 import merge from 'lodash-es/merge';
+import { copyConfig } from './config-mgmt';
 
 export interface ConditionState {
   view?: string;
@@ -109,7 +110,7 @@ export function getOverriddenConfig(
   overrides: Readonly<RawOverrides> | undefined,
   conditionState?: Readonly<ConditionState>,
 ): RawFrigateCardConfig {
-  const output = structuredClone(config);
+  const output = copyConfig(config);
   let overridden = false;
   if (overrides) {
     for (const override of overrides) {

--- a/src/config-mgmt.ts
+++ b/src/config-mgmt.ts
@@ -1,3 +1,4 @@
+import cloneDeep from 'lodash-es/cloneDeep'
 import get from 'lodash-es/get';
 import isEqual from 'lodash-es/isEqual';
 import set from 'lodash-es/set';
@@ -107,8 +108,7 @@ export const upgradeConfig = function (obj: RawFrigateCardConfig): boolean {
  * @returns `true` if the configuration is upgradeable.
  */
 export const isConfigUpgradeable = function (obj: RawFrigateCardConfig): boolean {
-  const newObj = structuredClone(obj);
-  return upgradeConfig(newObj);
+  return upgradeConfig(copyConfig(obj));
 };
 
 /**
@@ -138,8 +138,8 @@ export const trimConfig = function (obj: RawFrigateCardConfig): boolean {
  * @param obj Configuration to copy.
  * @returns A new deeply-copied configuration.
  */
-export const copyConfig = function (obj: RawFrigateCardConfig): RawFrigateCardConfig {
-  return structuredClone(obj);
+export const copyConfig = <T>(obj: T): T => {
+  return cloneDeep(obj);
 };
 
 /**

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -252,7 +252,7 @@ const options: EditorOptions = {
 export class FrigateCardEditor extends LitElement implements LovelaceCardEditor {
   @property({ attribute: false }) public hass?: HomeAssistant;
   @state() protected _config?: RawFrigateCardConfig;
-  @state() protected _defaults = structuredClone(frigateCardConfigDefaults);
+  @state() protected _defaults = copyConfig(frigateCardConfigDefaults);
 
   protected _initialized = false;
   protected _configUpgradeable = false;
@@ -481,7 +481,7 @@ export class FrigateCardEditor extends LitElement implements LovelaceCardEditor 
     } catch (_) {}
 
     if (unvalidatedProfile === 'high' || unvalidatedProfile === 'low') {
-      const defaults = structuredClone(frigateCardConfigDefaults);
+      const defaults = copyConfig(frigateCardConfigDefaults);
       if (unvalidatedProfile === 'low') {
         setLowPerformanceProfile(this._config, defaults);
       }


### PR DESCRIPTION
* Use lodash `cloneDeep` instead of `structuredClone` since there are still devices using an old webview.
* Generate a facade chunk so that HACS use of queryparameters does not end up re-importing the main card chunk.

Related: #861 