### PR TITLE
Add support for live substreams

### DIFF
--- a/src/camera-manager/engine.ts
+++ b/src/camera-manager/engine.ts
@@ -6,7 +6,6 @@ import {
   DataQuery,
   EventQuery,
   EventQueryResultsMap,
-  MediaMetadata,
   PartialEventQuery,
   PartialRecordingQuery,
   PartialRecordingSegmentsQuery,

--- a/src/camera-manager/frigate/engine-frigate.ts
+++ b/src/camera-manager/frigate/engine-frigate.ts
@@ -19,7 +19,6 @@ import {
   EventQuery,
   EventQueryResults,
   EventQueryResultsMap,
-  MediaMetadata,
   PartialEventQuery,
   PartialRecordingQuery,
   PartialRecordingSegmentsQuery,

--- a/src/camera-manager/store.ts
+++ b/src/camera-manager/store.ts
@@ -5,8 +5,26 @@ import { CameraConfigs, Engine } from './types';
 
 type CameraManagerEngineCameraIDMap = Map<CameraManagerEngine, Set<string>>;
 
-export class CameraManagerStore {
-  protected _configs: Map<string, CameraConfig> = new Map();
+export interface CameraManagerReadOnlyConfigStore {
+  getCameraConfig(cameraID: string): CameraConfig | null;
+  getCameraConfigForMedia(media: ViewMedia): CameraConfig | null;
+
+  hasCameraID(cameraID: string): boolean;
+  hasVisibleCameraID(cameraID: string): boolean;
+
+  getCameraCount(): number;
+  getVisibleCameraCount(): number;
+
+  getCameras(): CameraConfigs;
+  getVisibleCameras(): CameraConfigs;
+
+  getCameraIDs(): Set<string>;
+  getVisibleCameraIDs(): Set<string>;
+}
+
+export class CameraManagerStore implements CameraManagerReadOnlyConfigStore {
+  protected _allConfigs: Map<string, CameraConfig> = new Map();
+  protected _visibleConfigs: Map<string, CameraConfig> = new Map();
   protected _enginesByCamera: Map<string, CameraManagerEngine> = new Map();
   protected _enginesByType: Map<Engine, CameraManagerEngine> = new Map();
 
@@ -15,29 +33,44 @@ export class CameraManagerStore {
     cameraConfig: CameraConfig,
     engine: CameraManagerEngine,
   ): void {
-    this._configs.set(cameraID, cameraConfig);
+    if (!cameraConfig.hide) {
+      this._visibleConfigs.set(cameraID, cameraConfig);
+    }
+    this._allConfigs.set(cameraID, cameraConfig);
     this._enginesByCamera.set(cameraID, engine);
     this._enginesByType.set(engine.getEngineType(), engine);
   }
 
-  public getCameraCount(): number {
-    return this._configs.size;
+  public getCameraConfig(cameraID: string): CameraConfig | null {
+    return this._allConfigs.get(cameraID) ?? null;
   }
 
   public hasCameraID(cameraID: string): boolean {
-    return this._configs.has(cameraID);
+    return this._allConfigs.has(cameraID);
+  }
+  public hasVisibleCameraID(cameraID: string): boolean {
+    return this._visibleConfigs.has(cameraID);
   }
 
-  public getCameraConfig(cameraID: string): CameraConfig | null {
-    return this._configs.get(cameraID) ?? null;
+  public getCameraCount(): number {
+    return this._allConfigs.size;
+  }
+  public getVisibleCameraCount(): number {
+    return this._visibleConfigs.size;
   }
 
   public getCameras(): CameraConfigs {
-    return this._configs;
+    return this._allConfigs;
+  }
+  public getVisibleCameras(): CameraConfigs {
+    return this._visibleConfigs;
   }
 
   public getCameraIDs(): Set<string> {
-    return new Set(this._configs.keys());
+    return new Set(this._allConfigs.keys());
+  }
+  public getVisibleCameraIDs(): Set<string> {
+    return new Set(this._visibleConfigs.keys());
   }
 
   public getCameraConfigForMedia(media: ViewMedia): CameraConfig | null {

--- a/src/components/media-filter.ts
+++ b/src/components/media-filter.ts
@@ -31,10 +31,7 @@ import { MediaQueriesClassifier } from '../view/media-queries-classifier';
 import { View } from '../view/view';
 import { CameraManager } from '../camera-manager/manager';
 import { HomeAssistant } from 'custom-card-helpers';
-import {
-  MediaMetadata,
-  QueryType,
-} from '../camera-manager/types';
+import { DataQuery, MediaMetadata, QueryType } from '../camera-manager/types';
 import format from 'date-fns/format';
 import endOfMonth from 'date-fns/endOfMonth';
 import isEqual from 'lodash-es/isEqual';
@@ -168,7 +165,7 @@ class FrigateCardMediaFilter extends ScopedRegistryHost(LitElement) {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _ev: CustomEvent<{ value: unknown }>,
   ): Promise<void> {
-    const cameras = this.cameraManager?.getCameras();
+    const cameras = this.cameraManager?.getStore().getVisibleCameras();
     if (!this.hass || !cameras || !this.cameraManager || !this.view) {
       return;
     }
@@ -269,7 +266,7 @@ class FrigateCardMediaFilter extends ScopedRegistryHost(LitElement) {
 
   protected willUpdate(changedProps: PropertyValues): void {
     if (changedProps.has('cameraManager')) {
-      const cameras = this.cameraManager?.getCameras();
+      const cameras = this.cameraManager?.getStore().getVisibleCameras();
       if (cameras) {
         this._cameraOptions = Array.from(cameras.keys()).map((cameraID) => ({
           value: cameraID,
@@ -321,7 +318,7 @@ class FrigateCardMediaFilter extends ScopedRegistryHost(LitElement) {
 
   protected _getDefaultsFromView(): MediaFilterCoreDefaults | null {
     const queries = this.view?.query?.getQueries();
-    const cameras = this.cameraManager?.getCameras();
+    const cameras = this.cameraManager?.getStore().getVisibleCameras();
     if (!this.view || !queries || !cameras) {
       return null;
     }
@@ -333,12 +330,12 @@ class FrigateCardMediaFilter extends ScopedRegistryHost(LitElement) {
     let favorite: MediaFilterCoreFavoriteSelection | undefined;
 
     const cameraIDSets = uniqWith(
-      queries.map((query) => query.cameraIDs),
+      queries.map((query: DataQuery) => query.cameraIDs),
       isEqual,
     );
-    // Special note: If all cameras are selected, this is the same as no
+    // Special note: If all visible cameras are selected, this is the same as no
     // selector at all.
-    if (cameraIDSets.length === 1 && queries[0].cameraIDs.size !== cameras.size) {
+    if (cameraIDSets.length === 1 && isEqual(queries[0].cameraIDs, cameras)) {
       cameraIDs = [...queries[0].cameraIDs];
     }
 

--- a/src/components/surround.ts
+++ b/src/components/surround.ts
@@ -22,6 +22,7 @@ import { ThumbnailCarouselTap } from './thumbnail-carousel.js';
 import './surround-basic.js';
 import { changeViewToRecentEventsForCameraAndDependents } from '../utils/media-to-view';
 import { getAllDependentCameras } from '../utils/camera.js';
+import type { DataQuery } from '../camera-manager/types';
 
 interface ThumbnailViewContext {
   // Whether or not to fetch thumbnails.
@@ -120,7 +121,7 @@ export class FrigateCardSurround extends LitElement {
     // user is scrubbing video).
     if (
       changedProperties.has('view') &&
-      View.isMediaChange(changedProperties.get('view'), this.view)
+      View.isMajorMediaChange(changedProperties.get('view'), this.view)
     ) {
       this._cameraIDsForTimeline = this._getCameraIDsForTimeline() ?? undefined;
     }
@@ -138,18 +139,20 @@ export class FrigateCardSurround extends LitElement {
   }
 
   protected _getCameraIDsForTimeline(): Set<string> | null {
-    const cameras = this.cameraManager?.getCameras();
-    if (!this.view || !cameras) {
+    if (!this.view) {
       return null;
     }
     if (this.view?.is('live')) {
-      return getAllDependentCameras(cameras, this.view.camera);
+      return getAllDependentCameras(
+        this.cameraManager,
+        this.view.camera,
+      );
     }
     if (this.view.isViewerView()) {
       return new Set(
         this.view.query
           ?.getQueries()
-          ?.map((query) => [...query.cameraIDs])
+          ?.map((query: DataQuery) => [...query.cameraIDs])
           .flat(),
       );
     }

--- a/src/components/timeline-core.ts
+++ b/src/components/timeline-core.ts
@@ -238,7 +238,7 @@ export class FrigateCardTimelineCore extends LitElement {
     const item = request.detail.item;
     const media = this._timelineSource?.dataset.get(item)?.media;
     const cameraConfig = media
-      ? this.cameraManager?.getCameraConfig(media.getCameraID()) ?? undefined
+      ? this.cameraManager?.getStore().getCameraConfigForMedia(media) ?? undefined
       : undefined;
 
     request.detail.hass = this.hass;
@@ -291,15 +291,9 @@ export class FrigateCardTimelineCore extends LitElement {
    * @returns A set of camera ids (may be empty).
    */
   protected _getTimelineCameraIDs(): Set<string> | null {
-    return this.cameraIDs ?? this._getAllCameraIDs();
-  }
-
-  /**
-   * Get all the keys of all cameras.
-   * @returns A set of camera ids (may be empty).
-   */
-  protected _getAllCameraIDs(): Set<string> | null {
-    return this.cameraManager?.getCameraIDs() ?? null;
+    return (
+      this.cameraIDs ?? this.cameraManager?.getStore().getVisibleCameraIDs() ?? null
+    );
   }
 
   /**
@@ -1042,11 +1036,7 @@ export class FrigateCardTimelineCore extends LitElement {
       changedProps.has('cameraIDs')
     ) {
       const cameraIDs = this._getTimelineCameraIDs();
-      if (
-        cameraIDs &&
-        this.cameraManager &&
-        this.timelineConfig
-      ) {
+      if (cameraIDs && this.cameraManager && this.timelineConfig) {
         this._timelineSource = new TimelineDataSource(
           this.cameraManager,
           cameraIDs,

--- a/src/const.ts
+++ b/src/const.ts
@@ -13,6 +13,7 @@ export const CONF_CAMERAS_ARRAY_FRIGATE_LABEL =
 export const CONF_CAMERAS_ARRAY_FRIGATE_URL = `${CONF_CAMERAS}.#.frigate.url` as const;
 export const CONF_CAMERAS_ARRAY_FRIGATE_ZONE = `${CONF_CAMERAS}.#.frigate.zone` as const;
 export const CONF_CAMERAS_ARRAY_GO2RTC_MODES = `${CONF_CAMERAS}.#.go2rtc.modes` as const;
+export const CONF_CAMERAS_ARRAY_HIDE = `${CONF_CAMERAS}.#.hide` as const;
 export const CONF_CAMERAS_ARRAY_ID = `${CONF_CAMERAS}.#.id` as const;
 export const CONF_CAMERAS_ARRAY_TITLE = `${CONF_CAMERAS}.#.title` as const;
 export const CONF_CAMERAS_ARRAY_ICON = `${CONF_CAMERAS}.#.icon` as const;

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -130,6 +130,7 @@ import {
   CONF_PERFORMANCE_FEATURES_MEDIA_CHUNK_SIZE,
   MEDIA_CHUNK_SIZE_MAX,
   CONF_CAMERAS_ARRAY_GO2RTC_MODES,
+  CONF_CAMERAS_ARRAY_HIDE,
 } from './const.js';
 import { localize } from './localize/localize.js';
 import frigate_card_editor_style from './scss/editor.scss';
@@ -1341,6 +1342,13 @@ export class FrigateCardEditor extends LitElement implements LovelaceCardEditor 
               ${this._renderStringInput(
                 getArrayConfigPath(CONF_CAMERAS_ARRAY_ID, cameraIndex),
               )}
+              ${this._renderSwitch(
+                getArrayConfigPath(
+                  CONF_CAMERAS_ARRAY_HIDE,
+                  cameraIndex,
+                ),
+                this._defaults.cameras.hide,
+              )}
               ${this._putInSubmenu(
                 MENU_CAMERAS_FRIGATE,
                 cameraIndex,
@@ -1604,6 +1612,7 @@ export class FrigateCardEditor extends LitElement implements LovelaceCardEditor 
                 })}
                 ${this._renderMenuButton('frigate') /* */}
                 ${this._renderMenuButton('cameras') /* */}
+                ${this._renderMenuButton('substreams') /* */}
                 ${this._renderMenuButton('live') /* */}
                 ${this._renderMenuButton('clips') /* */}
                 ${this._renderMenuButton('snapshots')}

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -33,6 +33,7 @@
           "mjpeg": "Motion JPEG (MJPEG)"
         }
       },
+      "hide": "Hide camera from UI",
       "icon": "Icon for this camera (Autodetected from entity)",
       "id": "Unique id for this camera in this card",
       "live_provider": "Live view provider for this camera",
@@ -239,6 +240,7 @@
         "media_player": "Send to media player",
         "priority": "Priority",
         "snapshots": "Snapshots",
+        "substreams": "Substream(s)",
         "timeline": "Timeline",
         "recordings": "Recordings"
       },
@@ -368,10 +370,11 @@
     "live_camera_unavailable": "Camera unavailable",
     "no_camera_engine": "Could not determine suitable engine for camera",
     "no_camera_entity": "Could not find camera entity",
+    "no_camera_entity_for_triggers": "A camera entity is required in order to autodetect triggers",
     "no_camera_id": "Could not determine camera id for the following camera, may need to set 'id' parameter manually",
     "no_camera_name": "Could not determine a Frigate camera name for camera (or one of its dependents), please specify either 'camera_entity' or 'camera_name'",
-    "no_cameras": "No valid cameras found, you must configure at least one camera entry",
     "no_live_camera": "The camera_entity parameter must be set and valid for this live provider",
+    "no_visible_cameras": "No visible cameras found, you must configure at least one non-hidden camera",
     "reconnecting": "Reconnecting",
     "timeline_no_cameras": "No Frigate cameras to show in timeline",
     "troubleshooting": "Check troubleshooting",

--- a/src/localize/languages/it.json
+++ b/src/localize/languages/it.json
@@ -23,6 +23,7 @@
         "url": "Frigate URL del server",
         "zone": "Frigate zona"
       },
+      "hide": "",
       "icon": "Icona per questa telecamera (Autoidentificato dall'entità)",
       "id": "ID univoco per questa telecamera in questa carta",
       "live_provider": "Provider di visualizzazione dal vivo per questa telecamera",
@@ -223,6 +224,7 @@
         "live": "Abitare",
         "media_player": "Invia a Media Player",
         "priority": "Priorità",
+        "substreams": "",
         "snapshots": "Istantanee",
         "timeline": "Timeline"
       },
@@ -347,10 +349,11 @@
     "live_camera_unavailable": "Telecamera non disponibile",
     "no_camera_engine": "",
     "no_camera_entity": "",
+    "no_camera_entity_for_triggers": "",
     "no_camera_id": "Impossibile determinare l'ID della telecamera , potrebbe essere necessario impostare manualmente il parametro 'ID'",
     "no_camera_name": "Impossibile determinare un nome della telecamera in Frigate, si prega di specificare 'camera_enty' o 'camera_name'",
-    "no_cameras": "Nessuna telecamera valida trovata, è necessario configurare almeno una voce della telecamera",
     "no_live_camera": "Il parametro fotocamera_enty deve essere impostato e valido per questo provider live",
+    "no_visible_cameras": "",
     "reconnecting": "Riconnessione",
     "timeline_no_cameras": "Nessuna telecamera damostrare in Frigate nella timeline",
     "troubleshooting": "Controllare la risoluzione dei problemi",

--- a/src/localize/languages/pt-BR.json
+++ b/src/localize/languages/pt-BR.json
@@ -23,6 +23,7 @@
         "url": "URL do servidor Frigate",
         "zone": "Zona do Frigate"
       },
+      "hide": "",
       "icon": "Ícone para esta câmera (detectado automaticamente pela entidade)",
       "id": "ID exclusivo para esta câmera nesse cartão",
       "live_provider": "Provedor de visualização ao vivo para esta câmera",
@@ -223,6 +224,7 @@
         "live": "Ao vivo",
         "media_player": "Enviar para o reprodutor de mídia",
         "priority": "Prioridade",
+        "substreams": "",
         "snapshots": "Instantâneos",
         "timeline": "Linha do tempo"
       },
@@ -347,10 +349,11 @@
     "live_camera_unavailable": "",
     "no_camera_engine": "",
     "no_camera_entity": "",
+    "no_camera_entity_for_triggers": "",
     "no_camera_id": "Não foi possível determinar o ID da câmera para a câmera a seguir, pode ser necessário definir o parâmetro 'id' manualmente",
     "no_camera_name": "Não foi possível determinar o nome da câmera da Frigate, especifique 'camera_entity' ou 'camera_name' para a câmera a seguir",
-    "no_cameras": "Nenhuma câmera válida encontrada, você deve configurar pelo menos uma câmera",
     "no_live_camera": "O parâmetro camera_entity deve ser definido e válido para este provedor ativo",
+    "no_visible_cameras": "",
     "reconnecting": "Reconectando",
     "timeline_no_cameras": "Nenhuma câmera do Frigate para mostrar na linha do tempo",
     "troubleshooting": "Verifique a solução de problemas",

--- a/src/types.ts
+++ b/src/types.ts
@@ -199,7 +199,7 @@ const noActionSchema = schemaForType<
   }),
 );
 
-const frigateCardCustomactionsBaseSchema = customActionSchema.extend({
+const frigateCardCustomActionsBaseSchema = customActionSchema.extend({
   action: z
     .literal('custom:frigate-card-action')
     // Syntactic sugar to avoid 'fire-dom-event' as part of an external API.
@@ -227,18 +227,24 @@ const FRIGATE_CARD_GENERAL_ACTIONS = [
 const FRIGATE_CARD_ACTIONS = [
   ...FRIGATE_CARD_GENERAL_ACTIONS,
   'camera_select',
+  'live_substream_select',
   'media_player',
 ] as const;
 export type FrigateCardAction = (typeof FRIGATE_CARD_ACTIONS)[number];
 
-const frigateCardGeneralActionSchema = frigateCardCustomactionsBaseSchema.extend({
+const frigateCardGeneralActionSchema = frigateCardCustomActionsBaseSchema.extend({
   frigate_card_action: z.enum(FRIGATE_CARD_GENERAL_ACTIONS),
 });
-const frigateCardCameraSelectActionSchema = frigateCardCustomactionsBaseSchema.extend({
+const frigateCardCameraSelectActionSchema = frigateCardCustomActionsBaseSchema.extend({
   frigate_card_action: z.literal('camera_select'),
   camera: z.string(),
 });
-const frigateCarMediaPlayerActionSchema = frigateCardCustomactionsBaseSchema.extend({
+const frigateCardLiveDependencySelectActionSchema =
+  frigateCardCustomActionsBaseSchema.extend({
+    frigate_card_action: z.literal('live_substream_select'),
+    camera: z.string(),
+  });
+const frigateCarMediaPlayerActionSchema = frigateCardCustomActionsBaseSchema.extend({
   frigate_card_action: z.literal('media_player'),
   media_player: z.string(),
   media_player_action: z.enum(['play', 'stop']),
@@ -247,6 +253,7 @@ const frigateCarMediaPlayerActionSchema = frigateCardCustomactionsBaseSchema.ext
 export const frigateCardCustomActionSchema = z.union([
   frigateCardGeneralActionSchema,
   frigateCardCameraSelectActionSchema,
+  frigateCardLiveDependencySelectActionSchema,
   frigateCarMediaPlayerActionSchema,
 ]);
 export type FrigateCardCustomAction = z.infer<typeof frigateCardCustomActionSchema>;
@@ -398,6 +405,7 @@ const cameraConfigDefault = {
     all_cameras: false,
     cameras: [],
   },
+  hide: false,
   triggers: {
     motion: false,
     occupancy: true,
@@ -417,6 +425,9 @@ const cameraConfigSchema = z
     // specified).
     icon: z.string().optional(),
     title: z.string().optional(),
+
+    // Used to hide the camera (e.g. when used only as a dependency).
+    hide: z.boolean().optional(),
 
     // Optional identifier to separate different camera configurations used in
     // this card.
@@ -944,6 +955,7 @@ const menuConfigDefault = {
   buttons: {
     frigate: visibleButtonDefault,
     cameras: visibleButtonDefault,
+    substreams: visibleButtonDefault,
     live: visibleButtonDefault,
     clips: visibleButtonDefault,
     snapshots: visibleButtonDefault,
@@ -976,6 +988,7 @@ const menuConfigSchema = z
       .object({
         frigate: visibleButtonSchema.default(menuConfigDefault.buttons.frigate),
         cameras: visibleButtonSchema.default(menuConfigDefault.buttons.cameras),
+        substreams: visibleButtonSchema.default(menuConfigDefault.buttons.substreams),
         live: visibleButtonSchema.default(menuConfigDefault.buttons.live),
         clips: visibleButtonSchema.default(menuConfigDefault.buttons.clips),
         snapshots: visibleButtonSchema.default(menuConfigDefault.buttons.snapshots),

--- a/src/utils/action.ts
+++ b/src/utils/action.ts
@@ -1,16 +1,16 @@
 import {
-    ActionConfig,
-    handleActionConfig,
-    hasAction,
-    HomeAssistant
+  ActionConfig,
+  handleActionConfig,
+  hasAction,
+  HomeAssistant,
 } from 'custom-card-helpers';
 import {
-    Actions,
-    ActionsConfig,
-    ActionType,
-    FrigateCardAction,
-    FrigateCardCustomAction,
-    frigateCardCustomActionSchema
+  Actions,
+  ActionsConfig,
+  ActionType,
+  FrigateCardAction,
+  FrigateCardCustomAction,
+  frigateCardCustomActionSchema,
 } from '../types.js';
 
 /**
@@ -43,7 +43,7 @@ export function createFrigateCardCustomAction(
     media_player_action?: 'play' | 'stop';
   },
 ): FrigateCardCustomAction | null {
-  if (action === 'camera_select') {
+  if (action === 'camera_select' || action === 'live_substream_select') {
     if (!args?.camera) {
       return null;
     }

--- a/src/utils/camera.ts
+++ b/src/utils/camera.ts
@@ -1,3 +1,4 @@
+import { CameraManager } from '../camera-manager/manager.js';
 import { CameraConfig, RawFrigateCardConfig } from '../types.js';
 
 /**
@@ -25,14 +26,19 @@ export function getCameraID(
 
 /**
  * Get all cameras that depend on a given camera.
- * @param cameras Cameras map.
+ * @param cameraManager The camera manager.
  * @param cameraID ID of the target camera.
- * @returns A set of query parameters.
+ * @returns A set of dependent cameraIDs or null.
  */
 export const getAllDependentCameras = (
-  cameras: Map<string, CameraConfig>,
+  cameraManager?: CameraManager,
   cameraID?: string,
-): Set<string> => {
+): Set<string> | null => {
+  if (!cameraManager || !cameraID) {
+    return null;
+  }
+  const cameras = cameraManager.getStore().getCameras();
+
   const cameraIDs: Set<string> = new Set();
   const getDependentCameras = (cameraID: string): void => {
     const cameraConfig = cameras.get(cameraID);

--- a/src/utils/ha/entity-registry/index.ts
+++ b/src/utils/ha/entity-registry/index.ts
@@ -53,7 +53,7 @@ export class EntityRegistryManager {
   public async getExtendedEntity(
     hass: HomeAssistant,
     entityID: string,
-  ): Promise<ExtendedEntity | null> {
+  ): Promise<ExtendedEntity> {
     const cachedValue = this._extendedCache.get(entityID);
     if (cachedValue) {
       return cachedValue;

--- a/src/utils/media-to-view.ts
+++ b/src/utils/media-to-view.ts
@@ -27,11 +27,11 @@ export const changeViewToRecentEventsForCameraAndDependents = async (
     targetView?: FrigateCardView;
   },
 ): Promise<void> => {
-  const cameras = cameraManager.getCameras();
-  if (!cameras) {
+  const cameraIDs = getAllDependentCameras(cameraManager, view.camera);
+  if (!cameraIDs) {
     return;
   }
-  const cameraIDs = new Set(getAllDependentCameras(cameras, view.camera));
+
   const queries = createQueriesForEventsView(cameraManager, cardWideConfig, cameraIDs, {
     mediaType: options?.mediaType,
   });
@@ -83,18 +83,16 @@ export const changeViewToRecentRecordingForCameraAndDependents = async (
     targetView?: 'recording' | 'recordings';
   },
 ): Promise<void> => {
-  const cameras = cameraManager.getCameras();
-  if (!cameras) {
+  const cameraIDs = getAllDependentCameras(cameraManager, view.camera);
+  if (!cameraIDs) {
     return;
   }
 
-  const cameraIDs = new Set(getAllDependentCameras(cameras, view.camera));
   const queries = createQueriesForRecordingsView(
     cameraManager,
     cardWideConfig,
     cameraIDs,
   );
-
   if (!queries) {
     return;
   }

--- a/src/view/view.ts
+++ b/src/view/view.ts
@@ -39,12 +39,17 @@ export class View {
    * @param curr The current view.
    * @returns True if the view change is a real media change.
    */
-  public static isMediaChange(prev?: View, curr?: View): boolean {
+  public static isMajorMediaChange(prev?: View, curr?: View): boolean {
     return (
       !prev ||
       !curr ||
       prev.view !== curr.view ||
       prev.camera !== curr.camera ||
+      // When in live mode, take overrides into account in deciding if this is a
+      // major media change.
+      (curr.view === 'live' &&
+        prev.context?.live?.overrides?.get(prev.camera) !==
+          curr.context?.live?.overrides?.get(curr.camera)) ||
       // When in the live view, the queryResults contain the events that
       // happened in the past -- not reflective of the actual live media viewer
       // the user is seeing.


### PR DESCRIPTION
* Closes #934 
* Closes #898 

Example:

```yaml
[...]
cameras:
  - camera_entity: camera.sitting_room
    live_provider: image
    dependencies:
      cameras:
        - sitting_room_hd
  - camera_entity: camera.sitting_room
    title: Sitting Room HD
    live_provider: go2rtc
    id: sitting_room_hd
    # Do not show the HD camera independently on the UI.
    hide: true
menu:
  buttons:
    substreams:
      icon: mdi:high-definition
```
</details>