### PR TITLE
Remove unnecessary entity fetches

### DIFF
--- a/src/camera-manager/manager.ts
+++ b/src/camera-manager/manager.ts
@@ -189,7 +189,8 @@ export class CameraManager {
       camerasConfig.some((config) => hasAutoTriggers(config))
     ) {
       // ... then we need to populate the entity cache by fetching all entities
-      // from Home Assistant.
+      // from Home Assistant. Do this once upfront, to avoid each camera doing
+      // it.
       await entityRegistryManager.fetchEntityList(hass);
     }
 

--- a/src/card.ts
+++ b/src/card.ts
@@ -85,7 +85,7 @@ import { CameraManagerEngineFactory } from './camera-manager/engine-factory.js';
 import { log } from './utils/debug.js';
 import { EntityRegistryManager } from './utils/ha/entity-registry/index.js';
 import { EntityCache } from './utils/ha/entity-registry/cache.js';
-import { Entity, ExtendedEntity } from './utils/ha/entity-registry/types.js';
+import { Entity } from './utils/ha/entity-registry/types.js';
 import { getAllDependentCameras } from './utils/camera.js';
 
 /** A note on media callbacks:
@@ -214,10 +214,7 @@ class FrigateCard extends LitElement {
 
   constructor() {
     super();
-    this._entityRegistryManager = new EntityRegistryManager(
-      new EntityCache<Entity>(),
-      new EntityCache<ExtendedEntity>(),
-    );
+    this._entityRegistryManager = new EntityRegistryManager(new EntityCache());
   }
 
   /**

--- a/src/utils/ha/entity-registry/cache.ts
+++ b/src/utils/ha/entity-registry/cache.ts
@@ -1,7 +1,7 @@
-import { Entity, ExtendedEntity } from './types.js';
+import { Entity } from './types.js';
 
-export class EntityCache<T extends Entity | ExtendedEntity> {
-  protected _cache: Map<string, T> = new Map();
+export class EntityCache {
+  protected _cache: Map<string, Entity> = new Map();
 
   /**
    * Determine if the cache has a given entity_id.
@@ -21,25 +21,25 @@ export class EntityCache<T extends Entity | ExtendedEntity> {
   //   return [...this._cache.values()].find(func) ?? null;
   // }
 
-  public getMatches(func: (arg: T) => boolean): T[] {
+  public getMatches(func: (arg: Entity) => boolean): Entity[] {
     return [...this._cache.values()].filter(func);
   }
 
   /**
    * Get entity information given an id.
    * @param id The entity id.
-   * @returns The `ExtendedEntity` for this id.
+   * @returns The entity for this id.
    */
-  public get(id: string): T | undefined {
+  public get(id: string): Entity | undefined {
     return this._cache.get(id);
   }
 
   /**
    * Add a given entity to the cache.
-   * @param extendedEntity
+   * @param input The entity.
    */
-  public set(input: T | T[]): void {
-    const _set = (entity: T) => this._cache.set(entity.entity_id, entity);
+  public set(input: Entity | Entity[]): void {
+    const _set = (entity: Entity) => this._cache.set(entity.entity_id, entity);
 
     if (Array.isArray(input)) {
       input.forEach(_set);

--- a/src/utils/ha/entity-registry/index.ts
+++ b/src/utils/ha/entity-registry/index.ts
@@ -1,32 +1,18 @@
 import { HomeAssistant } from 'custom-card-helpers';
 import { homeAssistantWSRequest } from '..';
 import { EntityCache } from './cache';
-import {
-  Entity,
-  EntityList,
-  entityListSchema,
-  ExtendedEntity,
-  extendedEntitySchema,
-} from './types.js';
+import { Entity, EntityList, entitySchema, entityListSchema } from './types.js';
 
-type EntityRegistryCache = EntityCache<Entity>;
-type ExtendedEntityRegistryCache = EntityCache<ExtendedEntity>;
-
-// Tne `entity_registry/list` call returns a smaller set of information for
-// every entity, than the full `entity_registry/get` call returns for a single
-// entity. This class manages interactions with entities, caching results
-// (either the partial or extended versions) and fetching as necessary. Some
-// calls require every entity to be fetched, which may be non-trivial in size
-// (after which it is cached forever).
+// This class manages interactions with entities, caching results and fetching
+// as necessary. Some calls require every entity to be fetched, which may be
+// non-trivial in size (after which it is cached forever).
 
 export class EntityRegistryManager {
-  protected _cache: EntityRegistryCache;
-  protected _extendedCache: ExtendedEntityRegistryCache;
+  protected _cache: EntityCache;
   protected _fetchedEntityList = false;
 
-  constructor(cache: EntityCache<Entity>, extendedCache: EntityCache<ExtendedEntity>) {
+  constructor(cache: EntityCache) {
     this._cache = cache;
-    this._extendedCache = extendedCache;
   }
 
   public async getEntity(hass: HomeAssistant, entityID: string): Promise<Entity | null> {
@@ -35,11 +21,12 @@ export class EntityRegistryManager {
       return cachedEntity;
     }
 
-    const cachedExtendedEntity = this._extendedCache.get(entityID);
-    if (cachedExtendedEntity) {
-      return cachedExtendedEntity;
-    }
-    return await this.getExtendedEntity(hass, entityID);
+    const entity = await homeAssistantWSRequest<Entity>(hass, entitySchema, {
+      type: 'config/entity_registry/get',
+      entity_id: entityID,
+    });
+    this._cache.set(entity);
+    return entity;
   }
 
   public async getMatchingEntities(
@@ -48,26 +35,6 @@ export class EntityRegistryManager {
   ): Promise<Entity[]> {
     await this.fetchEntityList(hass);
     return this._cache.getMatches(func);
-  }
-
-  public async getExtendedEntity(
-    hass: HomeAssistant,
-    entityID: string,
-  ): Promise<ExtendedEntity> {
-    const cachedValue = this._extendedCache.get(entityID);
-    if (cachedValue) {
-      return cachedValue;
-    }
-    const extendedEntity = await homeAssistantWSRequest<ExtendedEntity>(
-      hass,
-      extendedEntitySchema,
-      {
-        type: 'config/entity_registry/get',
-        entity_id: entityID,
-      },
-    );
-    this._extendedCache.set(extendedEntity);
-    return extendedEntity;
   }
 
   public async getEntities(
@@ -82,21 +49,6 @@ export class EntityRegistryManager {
       }
     };
     await Promise.all(entityIDs.map(_storeEntity));
-    return output;
-  }
-
-  public async getExtendedEntities(
-    hass: HomeAssistant,
-    entityIDs: string[],
-  ): Promise<Map<string, ExtendedEntity>> {
-    const output: Map<string, ExtendedEntity> = new Map();
-    const _storeExtendedEntity = async (entityID: string): Promise<void> => {
-      const extendedEntity = await this.getExtendedEntity(hass, entityID);
-      if (extendedEntity) {
-        output.set(entityID, extendedEntity);
-      }
-    };
-    await Promise.all(entityIDs.map(_storeExtendedEntity));
     return output;
   }
 

--- a/src/utils/ha/entity-registry/types.ts
+++ b/src/utils/ha/entity-registry/types.ts
@@ -1,19 +1,14 @@
 import { z } from 'zod';
 
-const entitySchema = z.object({
+export const entitySchema = z.object({
   config_entry_id: z.string().nullable(),
   disabled_by: z.string().nullable(),
   entity_id: z.string(),
   hidden_by: z.string().nullable(),
   platform: z.string(),
-});
-export type Entity = z.infer<typeof entitySchema>;
-
-export const extendedEntitySchema = entitySchema.extend({
-  // Extended entity results.
   unique_id: z.string().optional(),
 });
-export type ExtendedEntity = z.infer<typeof extendedEntitySchema>;
+export type Entity = z.infer<typeof entitySchema>;
 
 export const entityListSchema = entitySchema.array();
 export type EntityList = z.infer<typeof entityListSchema>;


### PR DESCRIPTION
* Home Assistant now makes `unique_id` available in entity list calls, so we can avoid many per-entity fetches in some situations (namely: automatic detection of motion & occupancy sensor entity_ids).
* Closes #984 