### PR TITLE
Add missing language strings for v5.0.0: `it`

### DIFF
--- a/src/localize/languages/it.json
+++ b/src/localize/languages/it.json
@@ -212,7 +212,7 @@
       "lazy_load": "Le telecamere dal vivo sono pigramente cariche",
       "lazy_unload": "Le telecamere dal vivo sono pigramente non caricate",
       "preload": "Precarica Live View in background",
-      "show_image_during_load": "",
+      "show_image_during_load": "Mostra un'immagine fissa durante il caricamento del live streaming",
       "transition_effect": "Effetto di transizione della telecamera dal vivo"
     },
     "media_viewer": {
@@ -247,7 +247,7 @@
           "matching": "Corrispondenza con l'allineamento del menu",
           "opposing": "Contrastare l'allineamento del menu"
         },
-        "camera_ui": "",
+        "camera_ui": "Interfaccia utente della fotocamera",
         "cameras": "Telecamere",
         "clips": "Clip",
         "download": "Download",


### PR DESCRIPTION
Checking the file I realized that I have not translated two strings. Correct