### PR TITLE
Add `inlang` to make the contribution of translations easier

### DIFF
--- a/inlang.config.js
+++ b/inlang.config.js
@@ -1,0 +1,28 @@
+// @ts-check
+
+/**
+ * @type { import("@inlang/core/config").DefineConfig }
+ */
+export async function defineConfig(env) {
+  const plugin = await env.$import(
+    "https://cdn.jsdelivr.net/gh/samuelstroschein/inlang-plugin-json@1/dist/index.js"
+  );
+
+  const { standardLintRules } = await env.$import(
+    "https://cdn.jsdelivr.net/gh/inlang/standard-lint-rules@1/dist/index.js"
+  );
+
+  const pluginConfig = {
+    pathPattern: "./src/localize/languages/{language}.json",
+  };
+
+  return {
+    referenceLanguage: "en",
+    languages: await plugin.getLanguages({ ...env, pluginConfig }),
+    readResources: (args) => plugin.readResources({ ...args, ...env, pluginConfig }),
+    writeResources: (args) => plugin.writeResources({ ...args, ...env, pluginConfig }),
+    lint: {
+      rules: [standardLintRules()],
+    },
+  };
+}


### PR DESCRIPTION
Added as suggested in https://github.com/blakeblackshear/frigate-hass-integration/pull/478#issuecomment-1518792669

### Description
This pull request adds the possibility for contributors and translators to manage translations in a UI instead of files with no overhead for the maintainers.

To get a UI for translations contained in this repository, an [inlang.config.js](https://inlang.com/documentation/config) has been created at the root of the repository.
**Note:** This link should be changed to point to _dermotduffy_ instead of _NiklasBuchfink_ after this PR has been merged.

### Preview
The changes of this PR and a live instance of the editor can be previewed with the following link https://inlang.com/editor/github.com/NiklasBuchfink/frigate-hass-card.

### Limitations
**Certain actions are slow**
inlang is running entirely on git, giving tremendous CI/CD and contribution power to localization. That means that the whole frigate-hass-card repo is cloned into the browser which makes certain actions like the initial load and pushing changes slow. Those limitations will be fixed with future releases and require no input from frigate-hass-card.