### PR TITLE
Safely handle invalid null `hass` objects

### DIFF
--- a/src/card-controller/message-manager.ts
+++ b/src/card-controller/message-manager.ts
@@ -1,4 +1,4 @@
-import { FrigateCardError, MESSAGE_TYPE_PRIORITIES, Message } from '../types';
+import { FrigateCardError, MESSAGE_TYPE_PRIORITIES, Message, MessageType } from '../types';
 import { errorToConsole } from '../utils/basic';
 import { CardMessageAPI } from './types';
 
@@ -28,6 +28,12 @@ export class MessageManager {
 
     if (hadMessage) {
       this._api.getCardElementManager().update();
+    }
+  }
+
+  public resetType(type: MessageType): void {
+    if (this._message?.type === type) {
+      this.reset();
     }
   }
 

--- a/src/utils/ha/index.ts
+++ b/src/utils/ha/index.ts
@@ -375,8 +375,5 @@ export const hasHAConnectionStateChanged = (
   oldHass: HomeAssistant | undefined | null,
   newHass: HomeAssistant | undefined | null,
 ): boolean => {
-  return (
-    (!oldHass && !newHass?.connected) ||
-    (!!oldHass && oldHass.connected !== !!newHass?.connected)
-  );
+  return oldHass?.connected !== newHass?.connected;
 };

--- a/tests/card-controller/hass-manager.test.ts
+++ b/tests/card-controller/hass-manager.test.ts
@@ -130,7 +130,29 @@ describe('HASSManager', () => {
       const reconnectedHASS = createHASS();
       manager.setHASS(reconnectedHASS);
 
-      expect(api.getViewManager().setViewDefault).toBeCalled();
+      expect(api.getMessageManager().resetType).toBeCalled();
+    });
+
+    it('hass is null', () => {
+      const api = createAPIWithoutMediaPlayers();
+      const manager = new HASSManager(api);
+      const connectedHASS = createHASS();
+      connectedHASS.connected = true;
+
+      manager.setHASS(connectedHASS);
+      manager.setHASS(null);
+
+      expect(api.getMessageManager().setMessageIfHigherPriority).toBeCalledWith(
+        expect.objectContaining({
+          message: 'Reconnecting',
+          icon: 'mdi:lan-disconnect',
+          type: 'connection',
+          dotdotdot: true,
+        }),
+      );
+
+      manager.setHASS(connectedHASS);
+      expect(api.getMessageManager().resetType).toBeCalled();
     });
   });
 

--- a/tests/card-controller/message-manager.test.ts
+++ b/tests/card-controller/message-manager.test.ts
@@ -71,6 +71,22 @@ describe('MessageManager', () => {
     expect(api.getCardElementManager().update).toBeCalled();
   });
 
+  it('should reset message that matches type', () => {
+    const api = createCardAPI();
+    const manager = new MessageManager(api);
+
+    const message = createMessage({ type: 'connection' });
+    manager.setMessageIfHigherPriority(message);
+    expect(manager.getMessage()).toBe(message);
+
+    manager.resetType('error');
+    expect(manager.getMessage()).toBe(message);
+
+    manager.resetType('connection');
+    expect(manager.getMessage()).toBeNull();
+    expect(manager.hasMessage()).toBeFalsy();
+  });
+
   it('should respect priority', () => {
     const api = createCardAPI();
     const manager = new MessageManager(api);

--- a/tests/utils/ha/index.test.ts
+++ b/tests/utils/ha/index.test.ts
@@ -1,0 +1,45 @@
+import { HomeAssistant } from 'custom-card-helpers';
+import { describe, expect, it } from 'vitest';
+import { hasHAConnectionStateChanged } from '../../../src/utils/ha/index.js';
+import { createHASS } from '../../test-utils.js';
+
+const createConnected = (connected: boolean): HomeAssistant => {
+  const hass = createHASS();
+  hass.connected = connected;
+  return hass;
+};
+
+describe('hasHAConnectionStateChanged', () => {
+  it('initially connected', () => {
+    expect(hasHAConnectionStateChanged(null, createConnected(true))).toBeTruthy();
+  });
+  it('initially disconnected', () => {
+    expect(hasHAConnectionStateChanged(null, createConnected(false))).toBeTruthy();
+  });
+  it('disconnected', () => {
+    expect(
+      hasHAConnectionStateChanged(createConnected(true), createConnected(false)),
+    ).toBeTruthy();
+  });
+  it('disconnected via absence', () => {
+    expect(hasHAConnectionStateChanged(createConnected(true), null)).toBeTruthy();
+  });
+  it('connected', () => {
+    expect(
+      hasHAConnectionStateChanged(createConnected(false), createConnected(true)),
+    ).toBeTruthy();
+  });
+  it('still disconnected', () => {
+    expect(
+      hasHAConnectionStateChanged(createConnected(false), createConnected(false)),
+    ).toBeFalsy();
+  });
+  it('still connected', () => {
+    expect(
+      hasHAConnectionStateChanged(createConnected(true), createConnected(true)),
+    ).toBeFalsy();
+  });
+  it('still absent', () => {
+    expect(hasHAConnectionStateChanged(null, null)).toBeFalsy();
+  });
+});


### PR DESCRIPTION
Related: #1276 