### PR TITLE
Add out-of-the-box Frigate PTZ support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ That's it!
 
 ### Manual Resource Management
 
-For most users, HACS should automatically add the necessary resources. Should this auto-registration does not work, you will need to complete one additional step.
+For most users, HACS should automatically add the necessary resources. Should this auto-registration not work you will need to complete one additional step.
 
 #### Lovelace in "Storage mode" (default)
 
@@ -167,11 +167,11 @@ See the [fully expanded cameras configuration example](#config-expanded-cameras)
 
 ##### Engine Capabilities
 
-|Engine|Live|Supports clips|Supports Snapshots|Supports Recordings|Supports Timeline|Favorite events|Favorite recordings|
-| - | - | - | - | - | - | - | - |
-|`frigate`| :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :heavy_multiplication_x: |
-|`generic`| :white_check_mark: | :heavy_multiplication_x: | :heavy_multiplication_x: | :heavy_multiplication_x: | :heavy_multiplication_x: | :heavy_multiplication_x: | :heavy_multiplication_x: |
-|`motioneye`| :white_check_mark: | :white_check_mark: | :white_check_mark: | :heavy_multiplication_x: | :white_check_mark: | :heavy_multiplication_x: | :heavy_multiplication_x: |
+|Engine|Live|Supports clips|Supports Snapshots|Supports Recordings|Supports Timeline|Supports PTZ out of the box|Supports manually configured PTZ|Favorite events|Favorite recordings|
+| - | - | - | - | - | - | - | - | - | - |
+|`frigate`| :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :heavy_multiplication_x: |
+|`generic`| :white_check_mark: | :heavy_multiplication_x: | :heavy_multiplication_x: | :heavy_multiplication_x: | :heavy_multiplication_x: | :heavy_multiplication_x: | :white_check_mark: | :heavy_multiplication_x: | :heavy_multiplication_x: |
+|`motioneye`| :white_check_mark: | :white_check_mark: | :white_check_mark: | :heavy_multiplication_x: | :white_check_mark: | :heavy_multiplication_x: | :white_check_mark: | :heavy_multiplication_x: | :heavy_multiplication_x: | 
 
 ##### Live providers supported per Engine
 
@@ -485,6 +485,7 @@ menu:
 | `timeline` | :white_check_mark: | The `timeline` menu button: show the event timeline. |
 | `media_player` | :white_check_mark: | The `media_player` menu button: sends the visible media to a remote media player. Supports Frigate clips, snapshots and live camera (only for cameras that specify a `camera_entity` and only using the default HA stream (equivalent to the `ha` live provider). `jsmpeg` or `webrtc-card` are not supported, although live can still be played as long as `camera_entity` is specified. In the player list, a `tap` will send the media to the player, a `hold` will stop the media on the player. |
 | `microphone` | :white_check_mark: | The `microphone` button allows usage of 2-way audio in certain configurations. See [Using 2-way audio](#using-2-way-audio). |
+| `show_ptz` | :white_check_mark: | The `show_ptz` button shows or hide the PTZ controls. |
 
 ##### Configuration on each button
 
@@ -627,6 +628,30 @@ live:
 | `disconnect_seconds` | `60` | :white_check_mark: | The number of seconds after microphone usage to disconnect the microphone from the stream. `0` implies never. Not relevant if `always_connected` is `true`.|
 
 See [Using 2-way audio](#using-2-way-audio) for more information about the very particular requirements that must be followed for 2-way audio to work.
+
+<a name="frigate-card-ptz"></a>
+
+#### Live: PTZ
+
+Controls a PTZ (Pan Tilt Zoom) controller overlay. All configuration is under:
+
+```yaml
+live:
+  ptz:
+```
+
+| Option | Default | Overridable | Description |
+| - | - | - | - | 
+| `mode` | `on` | :white_check_mark: | When `on` will show a PTZ control if so configured (manually, or by the camera engine), if `off` will not show any control. |
+| `position` | `bottom-right` | :white_check_mark: | Whether to position the control on the `top-left`, `top-right`, `bottom-left` or `bottom-right`. This may be overridden by using the `style` parameter to precisely control placement. |
+| `actions_left`, `actions_right`, `actions_up`, `actions_down`, `actions_zoom_in`, `actions_zoom_out`, `actions_home` | Default is set by camera engine of the selected camera | :white_check_mark: | The [Home Assistant actions](https://www.home-assistant.io/dashboards/actions/) to call when this icon is interacted with. |
+| `orientation` | `horizontal` | :white_check_mark: | Whether to show a `vertical` or `horizontal` PTZ control. |
+| `hide_pan_tilt` | `false` | :white_check_mark: | When `true` the Pan & Tilt buttons of the control is hidden |
+| `hide_zoom` | `false` | :white_check_mark: | When `true` the Zoom button of the control is hidden |
+| `hide_home` | `false` | :white_check_mark: | When `true` the Home button of the control is hidden |
+| `data_left`, `data_right`, `data_up`, `data_down`, `data_zoom_in`, `data_zoom_out`, `data_home` | | :white_check_mark: | Shorthand for a `tap_action` that calls the `service` with the data provided in this argument. Internally, this is just translated into the longer-form `actions_[button]`. If both `actions_X` and `data_X` are specified, `actions_X` takes priority. This is compatible with [AlexxIT's WebRTC Card PTZ configuration](https://github.com/AlexxIT/WebRTC/wiki/PTZ-Config-Examples). |
+| `service` | | :white_check_mark: | An optional Home Assistant service to call when the `data_` parameters are used. |
+| `style` | | :white_check_mark: | Optionally position and style the element using CSS. Similar to [Picture Element styling](https://www.home-assistant.io/dashboards/picture-elements/#how-to-use-the-style-object), except without any default, e.g. `left: 42%` |
 
 <a name="live-display"></a>
 
@@ -1315,8 +1340,6 @@ elements to add special Frigate card functionality.
 | `custom:frigate-card-menu-submenu` | Add a configurable submenu dropdown. See [configuration below](#frigate-card-menu-submenu).|
 | `custom:frigate-card-menu-submenu-select` | Add a submenu based on a `select` or `input_select`. See [configuration below](#frigate-card-submenu-select).|
 | `custom:frigate-card-conditional` | Restrict a set of elements to only render when the card is showing particular a particular [view](#views). See [configuration below](#frigate-card-conditional).|
-| `custom:frigate-card-ptz` | Add a PTZ (Pan Tilt Zoom) controller overlay. See [configuration below](#frigate-card-ptz).|
-
 
 **Note**: ℹ️ Manual positioning of custom menu icons or submenus via the `style`
 parameter is not supported as the menu buttons displayed are context sensitive
@@ -1377,19 +1400,6 @@ Parameters for the `custom:frigate-card-conditional` element:
  `elements` | The elements to render. Can be any supported element, include additional condition or custom elements. |
 | `conditions` | A set of conditions that must evaluate to true in order for the elements to be rendered. See [Frigate Card Conditions](#frigate-card-conditions). |
 
-#### `custom:frigate-card-ptz`
-
-Parameters for the `custom:frigate-card-ptz` element:
-
-| Parameter | Default | Description |
-| ------------- | - | -------------------------------------------- |
-| `type` | | Must be `custom:frigate-card-ptz`. |
-| `style` | `translate(-50%, -50%)` | Position and style the element using CSS. See [Picture Element styling](https://www.home-assistant.io/dashboards/picture-elements/#how-to-use-the-style-object). |
-| `orientation` | `vertical` | Whether to show a `vertical` or `horizontal` PTZ control. |
-| `actions_left`, `actions_right`, `actions_up`, `actions_down`, `actions_zoom_in`, `actions_zoom_out`, `actions_home` | The [Home Assistant actions](https://www.home-assistant.io/dashboards/actions/) to call when this icon is interacted with. |
-| `data_left`, `data_right`, `data_up`, `data_down`, `data_zoom_in`, `data_zoom_out`, `data_home` | Shorthand for a `tap_action` that calls the `service` with the data provided in this argument. Internally, this is just translated into the longer-form `actions_[button]`. If both `actions_X` and `data_X` are specified, `actions_X` takes priority. This is compatible with [AlexxIT's WebRTC Card PTZ configuration](https://github.com/AlexxIT/WebRTC/wiki/PTZ-Config-Examples). |
-| `service` | | An optional Home Assistant service to call when the `data_` parameters are used. |
-
 <a name="frigate-card-actions"></a>
 
 ### Special Actions
@@ -1399,7 +1409,7 @@ Parameters for the `custom:frigate-card-ptz` element:
 | Parameter | Description |
 | - | - |
 | `action` | Must be `custom:frigate-card-action`. |
-| `frigate_card_action` | Call a Frigate Card action. Acceptable values are `default`, `clip`, `clips`, `image`, `live`, `recording`, `recordings`, `snapshot`, `snapshots`, `download`, `timeline`, `camera_ui`, `fullscreen`, `camera_select`, `menu_toggle`, `media_player`, `live_substream_on`, `live_substream_off`, `live_substream_select`, `expand`, `microphone_mute`, `microphone_unmute`, `mute`, `unmute`, `play`, `pause`, `screenshot`|
+| `frigate_card_action` | Call a Frigate Card action. Acceptable values are `default`, `clip`, `clips`, `image`, `live`, `recording`, `recordings`, `snapshot`, `snapshots`, `download`, `timeline`, `camera_ui`, `fullscreen`, `camera_select`, `menu_toggle`, `media_player`, `live_substream_on`, `live_substream_off`, `live_substream_select`, `expand`, `microphone_mute`, `microphone_unmute`, `mute`, `unmute`, `play`, `pause`, `screenshot`, `show_ptz`, `ptz`|
 
 <a name="custom-actions"></a>
 
@@ -1421,6 +1431,8 @@ Parameters for the `custom:frigate-card-ptz` element:
 |`mute`, `unmute`| Mute or unmute the loaded media. |
 |`play`, `pause`| Play or pause the loaded media. |
 |`screenshot`| Take a screenshot of the loaded media (e.g. a still from a video). |
+|`show_ptz`| Show or hide the PTZ controls. Takes a `show_ptz` boolean parameter to indicate whether the controls show be shown or not. |
+|`ptz`| Execute a native PTZ action (only for native out-of-the-box PTZ camera engines, e.g. Frigate). Takes a required `ptz_action` parameter that is one of `left`, `right`, `up`, `down`, `zoom_in`, `zoom_out` or `preset`. Takes an optional `ptz_phase` parameter that is one of `start` or `stop` to start or stop the movement discretely. Takes an optional `ptz_preset` parameter as the preset to execute when the `ptz_action` parameter is `preset`. |
 
 <a name="views"></a>
 
@@ -1438,6 +1450,7 @@ This card supports several different views:
 |`recordings`|Shows a gallery of recent (last day) recordings for this camera and its dependents.|
 |`recording`|Shows a viewer for the most recent recording for this camera. Can also be accessed by holding down the `recordings` menu icon.|
 |`image`|Shows a static image specified by the `image` parameter, can be used as a discrete default view or a screensaver (via `view.timeout_seconds`).|
+|`timeline`|Shows an event timeline.|
 
 ### Navigating From A Snapshot To A Clip
 
@@ -2012,6 +2025,11 @@ menu:
       enabled: false
       alignment: matching
       icon: mdi:play
+    show_ptz:
+      priority: 50
+      enabled: false
+      alignment: matching
+      icon: mdi:pan
   button_size: 40
 ```
 </details>
@@ -2066,6 +2084,29 @@ live:
   microphone:
     always_connected: false
     disconnect_seconds: 60
+  ptz:
+    mode: on
+    position: bottom-right
+    orientation: horizontal
+    hide_pan_tilt: false
+    hide_zoom: false
+    hide_home: false
+    style:
+      # Optionally override the default style.
+      right: 5%
+    # Manually specifying actions.
+    actions_left:
+      tap_action:
+        action: call-service
+        service: sonoff.send_command
+        service_data:
+          device: '048123'
+          cmd: left 
+    # Equivalent short form PTZ actions (only right button shown)
+    service: sonoff.send_command
+    data_right:
+      device: '048123'
+      cmd: right
   display:
     mode: single
     grid_selected_width_factor: 2
@@ -2432,31 +2473,6 @@ elements:
           state: on
           state_not: off
       media_loaded: true
-    # Full form PTZ actions (only left button shown).
-  - type: custom:frigate-card-ptz
-    orientation: vertical
-    style:
-      transform: none
-      right: 5%
-      top: 50%
-    actions_left:
-      tap_action:
-        action: call-service
-        service: sonoff.send_command
-        service_data:
-          device: '048123'
-          cmd: left 
-    # Equivalent short form PTZ actions (only left button shown)
-  - type: custom:frigate-card-ptz
-    orientation: vertical
-    style:
-      transform: none
-      right: 20px
-      top: 180px
-    service: sonoff.send_command
-    data_left:
-      device: '048123'
-      cmd: left
 ```
 </details>
 
@@ -2562,6 +2578,21 @@ elements:
     tap_action:
       action: custom:frigate-card-action
       frigate_card_action: screenshot
+  - type: custom:frigate-card-menu-icon
+    icon: mdi:alpha-p-circle
+    title: Show PTZ
+    tap_action:
+      action: custom:frigate-card-action
+      frigate_card_action: show_ptz
+      show_ptz: true
+  - type: custom:frigate-card-menu-icon
+    icon: mdi:alpha-q-circle
+    title: Native PTZ Preset
+    tap_action:
+      action: custom:frigate-card-action
+      frigate_card_action: ptz
+      ptz_action: preset
+      ptz_preset: 'doorway
 ```
 </details>
 
@@ -3416,44 +3447,33 @@ elements:
 ```
 </details>
 
-### Using a PTZ picture element
+### Using a PTZ control
 
-The card supports a custom PTZ element (`custom:frigate-card-ptz`) to conveniently control pan, tilt and zoom for cameras.
+The card supports using PTZ controls to conveniently control pan, tilt and zoom for cameras.
 
 <details>
-  <summary>Expand: Using the native PTZ picture element</summary>
+  <summary>Expand: Using the PTZ controls</summary>
 
-This example shows the native PTZ element when the `live` or `image` view is displayed and the stream (media) has loaded.
+This example shows the PTZ controls of the `live` view. Note that if your camera engine supports it (e.g. `frigate`) this will just work out of the box with no configuration at all.
 
 ```yaml
 [...]
-elements:
-  - type: custom:frigate-card-conditional
-    conditions:
-      media_loaded: true
-      view:
-        - live
-        - image
-    elements:
-      - type: custom:frigate-card-ptz
-        orientation: horizontal
-        style:
-          transform: none
-          right: 20px
-          top: 180px
-        service: sonoff.send_command
-        data_left:
-          device: '048123'
-          cmd: left
-        data_right:
-          device: '048123'
-          cmd: right
-        data_up:
-          device: '048123'
-          cmd: up
-        data_down:
-          device: '048123'
-          cmd: down
+live:
+  ptz:
+    orientation: horizontal
+    service: sonoff.send_command
+    data_left:
+      device: '048123'
+      cmd: left
+    data_right:
+      device: '048123'
+      cmd: right
+    data_up:
+      device: '048123'
+      cmd: up
+    data_down:
+      device: '048123'
+      cmd: down
 ```
 </details>
 

--- a/src/action-handler-directive.ts
+++ b/src/action-handler-directive.ts
@@ -32,6 +32,7 @@ class ActionHandler extends HTMLElement implements ActionHandler {
   protected doubleClickTimer = new Timer();
 
   protected held = false;
+  protected started = false;
 
   public connectedCallback(): void {
     [
@@ -83,7 +84,12 @@ class ActionHandler extends HTMLElement implements ActionHandler {
         this.held = true;
       });
 
-      fireEvent(element, 'action', { action: 'start_tap' });
+      // Without this check we get double start_tap events from touchstart and
+      // mousedown events (on Android).
+      if (!this.started) {
+        this.started = true;
+        fireEvent(element, 'action', { action: 'start_tap' });
+      }
     };
 
     const end = (ev: Event): void => {
@@ -105,6 +111,7 @@ class ActionHandler extends HTMLElement implements ActionHandler {
 
       this.holdTimer.stop();
 
+      this.started = false;
       fireEvent(element, 'action', { action: 'end_tap' });
 
       if (options?.hasHold && this.held) {

--- a/src/camera-manager/camera.ts
+++ b/src/camera-manager/camera.ts
@@ -1,0 +1,44 @@
+import { CameraConfig } from '../config/types';
+import { localize } from '../localize/localize';
+import { CameraManagerEngine } from './engine';
+import { CameraNoIDError } from './error';
+import { CameraManagerCameraCapabilities } from './types';
+
+export class Camera {
+  protected _config: CameraConfig;
+  protected _engine: CameraManagerEngine;
+  protected _capabilities: CameraManagerCameraCapabilities;
+
+  constructor(
+    config: CameraConfig,
+    engine: CameraManagerEngine,
+    capabilities: CameraManagerCameraCapabilities,
+  ) {
+    this._config = config;
+    this._engine = engine;
+    this._capabilities = capabilities;
+  }
+
+  public getConfig(): CameraConfig {
+    return this._config;
+  }
+
+  public setID(cameraID: string): void {
+    this._config.id = cameraID;
+  }
+
+  public getID(): string {
+    if (this._config.id) {
+      return this._config.id;
+    }
+    throw new CameraNoIDError(localize('error.no_camera_id'));
+  }
+
+  public getEngine(): CameraManagerEngine {
+    return this._engine;
+  }
+
+  public getCapabilities(): CameraManagerCameraCapabilities {
+    return this._capabilities;
+  }
+}

--- a/src/camera-manager/engine.ts
+++ b/src/camera-manager/engine.ts
@@ -1,14 +1,18 @@
 import { HomeAssistant } from '@dermotduffy/custom-card-helpers';
-import { CameraConfig } from '../config/types';
+import {
+  CameraConfig,
+  PTZAction,
+  PTZPhase,
+} from '../config/types';
 import { ExtendedHomeAssistant } from '../types';
 import { EntityRegistryManager } from '../utils/ha/entity-registry';
 import { ViewMedia } from '../view/media';
+import { Camera } from './camera';
+import { CameraManagerReadOnlyConfigStore } from './store';
 import {
-  CameraConfigs,
   CameraEndpoint,
   CameraEndpoints,
   CameraEndpointsContext,
-  CameraManagerCameraCapabilities,
   CameraManagerCameraMetadata,
   CameraManagerMediaCapabilities,
   DataQuery,
@@ -37,57 +41,57 @@ export interface CameraManagerEngine {
     hass: HomeAssistant,
     entityRegistryManager: EntityRegistryManager,
     cameraConfig: CameraConfig,
-  ): Promise<CameraConfig>;
+  ): Promise<Camera>;
 
   generateDefaultEventQuery(
-    cameras: CameraConfigs,
+    store: CameraManagerReadOnlyConfigStore,
     cameraIDs: Set<string>,
     query: PartialEventQuery,
   ): EventQuery[] | null;
 
   generateDefaultRecordingQuery(
-    cameras: CameraConfigs,
+    store: CameraManagerReadOnlyConfigStore,
     cameraIDs: Set<string>,
     query: PartialRecordingQuery,
   ): RecordingQuery[] | null;
 
   generateDefaultRecordingSegmentsQuery(
-    cameras: CameraConfigs,
+    store: CameraManagerReadOnlyConfigStore,
     cameraIDs: Set<string>,
     query: PartialRecordingSegmentsQuery,
   ): RecordingSegmentsQuery[] | null;
 
   getEvents(
     hass: HomeAssistant,
-    cameras: CameraConfigs,
+    store: CameraManagerReadOnlyConfigStore,
     query: EventQuery,
     engineOptions?: EngineOptions,
   ): Promise<EventQueryResultsMap | null>;
 
   getRecordings(
     hass: HomeAssistant,
-    cameras: CameraConfigs,
+    store: CameraManagerReadOnlyConfigStore,
     query: RecordingQuery,
     engineOptions?: EngineOptions,
   ): Promise<RecordingQueryResultsMap | null>;
 
   getRecordingSegments(
     hass: HomeAssistant,
-    cameras: CameraConfigs,
+    store: CameraManagerReadOnlyConfigStore,
     query: RecordingSegmentsQuery,
     engineOptions?: EngineOptions,
   ): Promise<RecordingSegmentsQueryResultsMap | null>;
 
   generateMediaFromEvents(
     hass: HomeAssistant,
-    cameras: CameraConfigs,
+    store: CameraManagerReadOnlyConfigStore,
     query: EventQuery,
     results: QueryReturnType<EventQuery>,
   ): ViewMedia[] | null;
 
   generateMediaFromRecordings(
     hass: HomeAssistant,
-    cameras: CameraConfigs,
+    store: CameraManagerReadOnlyConfigStore,
     query: RecordingQuery,
     results: QueryReturnType<RecordingQuery>,
   ): ViewMedia[] | null;
@@ -109,7 +113,7 @@ export interface CameraManagerEngine {
 
   getMediaSeekTime(
     hass: HomeAssistant,
-    cameras: CameraConfigs,
+    store: CameraManagerReadOnlyConfigStore,
     media: ViewMedia,
     target: Date,
     engineOptions?: EngineOptions,
@@ -117,7 +121,7 @@ export interface CameraManagerEngine {
 
   getMediaMetadata(
     hass: HomeAssistant,
-    cameras: CameraConfigs,
+    store: CameraManagerReadOnlyConfigStore,
     query: MediaMetadataQuery,
     engineOptions?: EngineOptions,
   ): Promise<MediaMetadataQueryResultsMap | null>;
@@ -127,14 +131,20 @@ export interface CameraManagerEngine {
     cameraConfig: CameraConfig,
   ): CameraManagerCameraMetadata;
 
-  getCameraCapabilities(
-    cameraConfig: CameraConfig,
-  ): CameraManagerCameraCapabilities | null;
-
   getMediaCapabilities(media: ViewMedia): CameraManagerMediaCapabilities | null;
 
   getCameraEndpoints(
     cameraConfig: CameraConfig,
     context?: CameraEndpointsContext,
   ): CameraEndpoints | null;
+
+  executePTZAction(
+    hass: HomeAssistant,
+    cameraConfig: CameraConfig,
+    action: PTZAction,
+    options?: {
+      phase?: PTZPhase,
+      preset?: string,
+    }
+  ): Promise<void>;
 }

--- a/src/camera-manager/error.ts
+++ b/src/camera-manager/error.ts
@@ -1,3 +1,4 @@
 import { FrigateCardError } from '../types.js';
 
 export class CameraInitializationError extends FrigateCardError {}
+export class CameraNoIDError extends FrigateCardError {}

--- a/src/camera-manager/frigate/requests.ts
+++ b/src/camera-manager/frigate/requests.ts
@@ -8,6 +8,8 @@ import {
   eventSummarySchema,
   FrigateEvent,
   frigateEventsSchema,
+  PTZInfo,
+  ptzInfoSchema,
   recordingSegmentsSchema,
   RecordingSummary,
   recordingSummarySchema,
@@ -147,6 +149,23 @@ export const getEventSummary = async (
       type: 'frigate/events/summary',
       instance_id: clientID,
       timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    },
+    true,
+  );
+};
+
+export const getPTZInfo = async (
+  hass: HomeAssistant,
+  clientID: string,
+  cameraName: string,
+): Promise<PTZInfo> => {
+  return await homeAssistantWSRequest(
+    hass,
+    ptzInfoSchema,
+    {
+      type: 'frigate/ptz/info',
+      instance_id: clientID,
+      camera: cameraName,
     },
     true,
   );

--- a/src/camera-manager/frigate/types.ts
+++ b/src/camera-manager/frigate/types.ts
@@ -76,6 +76,13 @@ export const eventSummarySchema = z
   .array();
 export type EventSummary = z.infer<typeof eventSummarySchema>;
 
+export const ptzInfoSchema = z.object({
+  name: z.string().optional(),
+  features: z.string().array().optional(),
+  presets: z.string().array().optional(),
+});
+export type PTZInfo = z.infer<typeof ptzInfoSchema>;
+
 // ==============================
 // Frigate concrete query results
 // ==============================

--- a/src/camera-manager/generic/engine-generic.ts
+++ b/src/camera-manager/generic/engine-generic.ts
@@ -1,18 +1,22 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 import { HomeAssistant } from '@dermotduffy/custom-card-helpers';
-import { CameraConfig } from '../../config/types';
+import {
+  CameraConfig,
+  PTZAction,
+  PTZPhase
+} from '../../config/types';
 import { ExtendedHomeAssistant } from '../../types';
 import { getEntityIcon, getEntityTitle } from '../../utils/ha';
 import { EntityRegistryManager } from '../../utils/ha/entity-registry';
 import { ViewMedia } from '../../view/media';
+import { Camera } from '../camera';
 import { CameraManagerEngine } from '../engine';
+import { CameraManagerReadOnlyConfigStore } from '../store';
 import {
-  CameraConfigs,
   CameraEndpoint,
   CameraEndpoints,
   CameraEndpointsContext,
-  CameraManagerCameraCapabilities,
   CameraManagerCameraMetadata,
   CameraManagerMediaCapabilities,
   DataQuery,
@@ -29,7 +33,7 @@ import {
   RecordingQuery,
   RecordingQueryResultsMap,
   RecordingSegmentsQuery,
-  RecordingSegmentsQueryResultsMap,
+  RecordingSegmentsQueryResultsMap
 } from '../types';
 import { getCameraEntityFromConfig, getDefaultGo2RTCEndpoint } from '../utils.js';
 
@@ -42,12 +46,20 @@ export class GenericCameraManagerEngine implements CameraManagerEngine {
     _hass: HomeAssistant,
     _entityRegistryManager: EntityRegistryManager,
     cameraConfig: CameraConfig,
-  ): Promise<CameraConfig> {
-    return cameraConfig;
+  ): Promise<Camera> {
+    return new Camera(cameraConfig, this, {
+      canFavoriteEvents: false,
+      canFavoriteRecordings: false,
+      canSeek: false,
+      supportsClips: false,
+      supportsRecordings: false,
+      supportsSnapshots: false,
+      supportsTimeline: false,
+    });
   }
 
   public generateDefaultEventQuery(
-    _cameras: CameraConfigs,
+    _store: CameraManagerReadOnlyConfigStore,
     _cameraIDs: Set<string>,
     _query: PartialEventQuery,
   ): EventQuery[] | null {
@@ -55,7 +67,7 @@ export class GenericCameraManagerEngine implements CameraManagerEngine {
   }
 
   public generateDefaultRecordingQuery(
-    _cameras: CameraConfigs,
+    _store: CameraManagerReadOnlyConfigStore,
     _cameraIDs: Set<string>,
     _query: PartialRecordingQuery,
   ): RecordingQuery[] | null {
@@ -63,7 +75,7 @@ export class GenericCameraManagerEngine implements CameraManagerEngine {
   }
 
   public generateDefaultRecordingSegmentsQuery(
-    _cameras: CameraConfigs,
+    _store: CameraManagerReadOnlyConfigStore,
     _cameraIDs: Set<string>,
     _query: PartialRecordingSegmentsQuery,
   ): RecordingSegmentsQuery[] | null {
@@ -72,7 +84,7 @@ export class GenericCameraManagerEngine implements CameraManagerEngine {
 
   public async getEvents(
     _hass: HomeAssistant,
-    _cameras: CameraConfigs,
+    _store: CameraManagerReadOnlyConfigStore,
     _query: EventQuery,
     _engineOptions?: EngineOptions,
   ): Promise<EventQueryResultsMap | null> {
@@ -81,7 +93,7 @@ export class GenericCameraManagerEngine implements CameraManagerEngine {
 
   public async getRecordings(
     _hass: HomeAssistant,
-    _cameras: CameraConfigs,
+    _store: CameraManagerReadOnlyConfigStore,
     _query: RecordingQuery,
     _engineOptions?: EngineOptions,
   ): Promise<RecordingQueryResultsMap | null> {
@@ -90,7 +102,7 @@ export class GenericCameraManagerEngine implements CameraManagerEngine {
 
   public async getRecordingSegments(
     _hass: HomeAssistant,
-    _cameras: CameraConfigs,
+    _store: CameraManagerReadOnlyConfigStore,
     _query: RecordingSegmentsQuery,
     _engineOptions?: EngineOptions,
   ): Promise<RecordingSegmentsQueryResultsMap | null> {
@@ -99,7 +111,7 @@ export class GenericCameraManagerEngine implements CameraManagerEngine {
 
   public generateMediaFromEvents(
     _hass: HomeAssistant,
-    _cameras: CameraConfigs,
+    _store: CameraManagerReadOnlyConfigStore,
     _query: EventQuery,
     _results: QueryReturnType<EventQuery>,
   ): ViewMedia[] | null {
@@ -108,7 +120,7 @@ export class GenericCameraManagerEngine implements CameraManagerEngine {
 
   public generateMediaFromRecordings(
     _hass: HomeAssistant,
-    _cameras: CameraConfigs,
+    _store: CameraManagerReadOnlyConfigStore,
     _query: RecordingQuery,
     _results: QueryReturnType<RecordingQuery>,
   ): ViewMedia[] | null {
@@ -138,7 +150,7 @@ export class GenericCameraManagerEngine implements CameraManagerEngine {
 
   public async getMediaSeekTime(
     _hass: HomeAssistant,
-    _cameras: CameraConfigs,
+    _store: CameraManagerReadOnlyConfigStore,
     _media: ViewMedia,
     _target: Date,
     _engineOptions?: EngineOptions,
@@ -148,7 +160,7 @@ export class GenericCameraManagerEngine implements CameraManagerEngine {
 
   public async getMediaMetadata(
     _hass: HomeAssistant,
-    _cameras: CameraConfigs,
+    _store: CameraManagerReadOnlyConfigStore,
     _query: MediaMetadataQuery,
     _engineOptions?: EngineOptions,
   ): Promise<MediaMetadataQueryResultsMap | null> {
@@ -173,20 +185,6 @@ export class GenericCameraManagerEngine implements CameraManagerEngine {
     };
   }
 
-  public getCameraCapabilities(
-    _cameraConfig: CameraConfig,
-  ): CameraManagerCameraCapabilities | null {
-    return {
-      canFavoriteEvents: false,
-      canFavoriteRecordings: false,
-      canSeek: false,
-      supportsClips: false,
-      supportsRecordings: false,
-      supportsSnapshots: false,
-      supportsTimeline: false,
-    };
-  }
-
   public getMediaCapabilities(_media: ViewMedia): CameraManagerMediaCapabilities | null {
     return null;
   }
@@ -201,5 +199,17 @@ export class GenericCameraManagerEngine implements CameraManagerEngine {
           go2rtc: go2rtc,
         }
       : null;
+  }
+
+  public async executePTZAction(
+    _hass: HomeAssistant,
+    _cameraConfig: CameraConfig,
+    _action: PTZAction,
+    _options?: {
+      phase?: PTZPhase;
+      preset?: string;
+    },
+  ): Promise<void> {
+    // Pass.
   }
 }

--- a/src/camera-manager/motioneye/engine-motioneye.ts
+++ b/src/camera-manager/motioneye/engine-motioneye.ts
@@ -8,25 +8,23 @@ import { CameraConfig } from '../../config/types';
 import { allPromises, formatDate, isValidDate } from '../../utils/basic';
 import {
   BrowseMediaStep,
-  BrowseMediaTarget,
+  BrowseMediaTarget
 } from '../../utils/ha/browse-media/browse-media-manager';
 import {
-  BROWSE_MEDIA_CACHE_SECONDS,
-  BrowseMedia,
-  MEDIA_CLASS_IMAGE,
+  BrowseMedia, BROWSE_MEDIA_CACHE_SECONDS, MEDIA_CLASS_IMAGE,
   MEDIA_CLASS_VIDEO,
-  RichBrowseMedia,
+  RichBrowseMedia
 } from '../../utils/ha/browse-media/types';
 import { ViewMedia } from '../../view/media';
 import {
   BrowseMediaCameraManagerEngine,
   getViewMediaFromBrowseMediaArray,
-  isMediaWithinDates,
+  isMediaWithinDates
 } from '../browse-media/engine-browse-media';
 import { BrowseMediaMetadata } from '../browse-media/types';
 import { CAMERA_MANAGER_ENGINE_EVENT_LIMIT_DEFAULT } from '../engine';
+import { CameraManagerReadOnlyConfigStore } from '../store';
 import {
-  CameraConfigs,
   CameraEndpoint,
   CameraEndpoints,
   CameraEndpointsContext,
@@ -41,7 +39,7 @@ import {
   MediaMetadataQueryResultsMap,
   QueryResults,
   QueryResultsType,
-  QueryReturnType,
+  QueryReturnType
 } from '../types';
 import motioneyeLogo from './assets/motioneye-logo.svg';
 import { MotionEyeEventQueryResults } from './types';
@@ -126,7 +124,7 @@ export class MotionEyeCameraManagerEngine extends BrowseMediaCameraManagerEngine
   // Get media directories that match a given criteria.
   protected async _getMatchingDirectories(
     hass: HomeAssistant,
-    cameras: CameraConfigs,
+    store: CameraManagerReadOnlyConfigStore,
     cameraID: string,
     matchOptions?: {
       start?: Date;
@@ -136,11 +134,11 @@ export class MotionEyeCameraManagerEngine extends BrowseMediaCameraManagerEngine
     } | null,
     engineOptions?: EngineOptions,
   ): Promise<RichBrowseMedia<BrowseMediaMetadata>[] | null> {
-    const cameraEntityID = cameras.get(cameraID)?.camera_entity;
+    const cameraConfig = store.getCameraConfig(cameraID);
+    const cameraEntityID = cameraConfig?.camera_entity;
     const entity = cameraEntityID ? this._cameraEntities.get(cameraEntityID) : null;
     const configID = entity?.config_entry_id;
     const deviceID = entity?.device_id;
-    const cameraConfig = cameras.get(cameraID);
 
     if (!configID || !deviceID || !cameraConfig) {
       return null;
@@ -206,7 +204,7 @@ export class MotionEyeCameraManagerEngine extends BrowseMediaCameraManagerEngine
 
   public async getEvents(
     hass: HomeAssistant,
-    cameras: CameraConfigs,
+    store: CameraManagerReadOnlyConfigStore,
     query: EventQuery,
     engineOptions?: EngineOptions,
   ): Promise<EventQueryResultsMap | null> {
@@ -225,14 +223,14 @@ export class MotionEyeCameraManagerEngine extends BrowseMediaCameraManagerEngine
         return;
       }
 
-      const cameraConfig = cameras.get(cameraID);
+      const cameraConfig = store.getCameraConfig(cameraID);
       if (!cameraConfig) {
         return;
       }
 
       const directories = await this._getMatchingDirectories(
         hass,
-        cameras,
+        store,
         cameraID,
         perCameraQuery,
         engineOptions,
@@ -309,7 +307,7 @@ export class MotionEyeCameraManagerEngine extends BrowseMediaCameraManagerEngine
 
   public generateMediaFromEvents(
     _hass: HomeAssistant,
-    _cameras: CameraConfigs,
+    _store: CameraManagerReadOnlyConfigStore,
     _query: EventQuery,
     results: QueryReturnType<EventQuery>,
   ): ViewMedia[] | null {
@@ -321,7 +319,7 @@ export class MotionEyeCameraManagerEngine extends BrowseMediaCameraManagerEngine
 
   public async getMediaMetadata(
     hass: HomeAssistant,
-    cameras: CameraConfigs,
+    store: CameraManagerReadOnlyConfigStore,
     query: MediaMetadataQuery,
     engineOptions?: EngineOptions,
   ): Promise<MediaMetadataQueryResultsMap | null> {
@@ -340,7 +338,7 @@ export class MotionEyeCameraManagerEngine extends BrowseMediaCameraManagerEngine
     const getDaysForCamera = async (cameraID: string): Promise<void> => {
       const directories = await this._getMatchingDirectories(
         hass,
-        cameras,
+        store,
         cameraID,
         null,
         engineOptions,

--- a/src/camera-manager/store.ts
+++ b/src/camera-manager/store.ts
@@ -1,7 +1,8 @@
 import { CameraConfig } from '../config/types';
 import { ViewMedia } from '../view/media';
+import { Camera } from './camera';
 import { CameraManagerEngine } from './engine';
-import { CameraConfigs, Engine } from './types';
+import { Engine } from './types';
 
 type CameraManagerEngineCameraIDMap = Map<CameraManagerEngine, Set<string>>;
 
@@ -10,74 +11,82 @@ export interface CameraManagerReadOnlyConfigStore {
   getCameraConfigForMedia(media: ViewMedia): CameraConfig | null;
 
   hasCameraID(cameraID: string): boolean;
-  hasVisibleCameraID(cameraID: string): boolean;
 
+  getCamera(cameraID: string): Camera | null;
   getCameraCount(): number;
   getVisibleCameraCount(): number;
 
-  getCameras(): CameraConfigs;
-  getVisibleCameras(): CameraConfigs;
+  getCameraConfigs(cameraIDs?: Iterable<string>): IterableIterator<CameraConfig>;
+  getCameraConfigEntries(
+    cameraIDs?: Iterable<string>,
+  ): IterableIterator<[string, CameraConfig]>;
 
   getCameraIDs(): Set<string>;
   getVisibleCameraIDs(): Set<string>;
+
+  getAllDependentCameras(cameraID: string): Set<string>;
 }
 
 export class CameraManagerStore implements CameraManagerReadOnlyConfigStore {
-  protected _allConfigs: Map<string, CameraConfig> = new Map();
-  protected _visibleConfigs: Map<string, CameraConfig> = new Map();
-  protected _enginesByCamera: Map<string, CameraManagerEngine> = new Map();
+  protected _cameras: Map<string, Camera> = new Map();
   protected _enginesByType: Map<Engine, CameraManagerEngine> = new Map();
 
-  public addCamera(
-    cameraID: string,
-    cameraConfig: CameraConfig,
-    engine: CameraManagerEngine,
-  ): void {
-    if (!cameraConfig.hide) {
-      this._visibleConfigs.set(cameraID, cameraConfig);
-    }
-    this._allConfigs.set(cameraID, cameraConfig);
-    this._enginesByCamera.set(cameraID, engine);
-    this._enginesByType.set(engine.getEngineType(), engine);
+  public addCamera(camera: Camera): void {
+    this._cameras.set(camera.getID(), camera);
+    this._enginesByType.set(camera.getEngine().getEngineType(), camera.getEngine());
   }
-
   public reset(): void {
-    this._allConfigs.clear();
-    this._visibleConfigs.clear();
-    this._enginesByCamera.clear();
+    this._cameras.clear();
     this._enginesByType.clear();
   }
 
+  public getCamera(cameraID: string): Camera | null {
+    return this._cameras.get(cameraID) ?? null;
+  }
   public getCameraConfig(cameraID: string): CameraConfig | null {
-    return this._allConfigs.get(cameraID) ?? null;
+    return this._cameras.get(cameraID)?.getConfig() ?? null;
   }
 
   public hasCameraID(cameraID: string): boolean {
-    return this._allConfigs.has(cameraID);
-  }
-  public hasVisibleCameraID(cameraID: string): boolean {
-    return this._visibleConfigs.has(cameraID);
+    return this._cameras.has(cameraID);
   }
 
   public getCameraCount(): number {
-    return this._allConfigs.size;
+    return this._cameras.size;
   }
   public getVisibleCameraCount(): number {
-    return this._visibleConfigs.size;
+    return this.getVisibleCameraIDs().size;
   }
 
-  public getCameras(): CameraConfigs {
-    return this._allConfigs;
+  public getCameras(): Map<string, Camera> {
+    return this._cameras;
   }
-  public getVisibleCameras(): CameraConfigs {
-    return this._visibleConfigs;
+
+  public *getCameraConfigs(
+    cameraIDs?: Iterable<string>,
+  ): IterableIterator<CameraConfig> {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for (const [_cameraID, config] of this.getCameraConfigEntries(cameraIDs)) {
+      yield config;
+    }
+  }
+  public *getCameraConfigEntries(
+    cameraIDs?: Iterable<string>,
+  ): IterableIterator<[string, CameraConfig]> {
+    for (const cameraID of cameraIDs ?? this._cameras.keys()) {
+      const config = this.getCameraConfig(cameraID);
+
+      if (config) {
+        yield [cameraID, config];
+      }
+    }
   }
 
   public getCameraIDs(): Set<string> {
-    return new Set(this._allConfigs.keys());
+    return new Set(this._cameras.keys());
   }
   public getVisibleCameraIDs(): Set<string> {
-    return new Set(this._visibleConfigs.keys());
+    return this._getMatchingCameraIDs((camera) => !camera.getConfig().hide);
   }
 
   public getCameraConfigForMedia(media: ViewMedia): CameraConfig | null {
@@ -89,7 +98,7 @@ export class CameraManagerStore implements CameraManagerReadOnlyConfigStore {
   }
 
   public getEngineForCameraID(cameraID: string): CameraManagerEngine | null {
-    return this._enginesByCamera.get(cameraID) ?? null;
+    return this._cameras.get(cameraID)?.getEngine() ?? null;
   }
 
   public getEnginesForCameraIDs(
@@ -114,7 +123,42 @@ export class CameraManagerStore implements CameraManagerReadOnlyConfigStore {
     return this.getEngineForCameraID(media.getCameraID());
   }
 
-  public getAllEngines(): CameraManagerEngine[] {
-    return [...this._enginesByType.values()];
+  /**
+   * Get all cameras that depend on a given camera.
+   * @param cameraManager The camera manager.
+   * @param cameraID ID of the target camera.
+   * @returns A set of dependent cameraIDs or null (since JS sets guarantee order,
+   * the first item in the set is guaranteed to be the cameraID itself).
+   */
+  public getAllDependentCameras(cameraID: string): Set<string> {
+    const cameraIDs: Set<string> = new Set();
+    const getDependentCameras = (cameraID: string): void => {
+      const cameraConfig = this.getCameraConfig(cameraID);
+      if (cameraConfig) {
+        cameraIDs.add(cameraID);
+        const dependentCameras: Set<string> = new Set();
+        cameraConfig.dependencies.cameras.forEach((item) => dependentCameras.add(item));
+        if (cameraConfig.dependencies.all_cameras) {
+          this.getCameraIDs().forEach((cameraID) => dependentCameras.add(cameraID));
+        }
+        for (const eventCameraID of dependentCameras) {
+          if (!cameraIDs.has(eventCameraID)) {
+            getDependentCameras(eventCameraID);
+          }
+        }
+      }
+    };
+    getDependentCameras(cameraID);
+    return cameraIDs;
+  }
+
+  protected _getMatchingCameraIDs(func: (camera: Camera) => boolean): Set<string> {
+    const output = new Set<string>();
+    for (const [cameraID, camera] of this._cameras.entries()) {
+      if (func(camera)) {
+        output.add(cameraID);
+      }
+    }
+    return output;
   }
 }

--- a/src/camera-manager/types.ts
+++ b/src/camera-manager/types.ts
@@ -1,4 +1,4 @@
-import { CameraConfig, FrigateCardView } from '../config/types';
+import { FrigateCardView } from '../config/types';
 import { ViewMedia } from '../view/media';
 
 // ====
@@ -91,6 +91,14 @@ export interface MediaMetadata {
   what?: Set<string>;
 }
 
+export type PTZMovementType = 'relative' | 'continuous';
+
+export interface PTZCapabilities {
+  panTilt?: PTZMovementType[];
+  zoom?: PTZMovementType[];
+  presets?: string[];
+}
+
 interface BaseCapabilities {
   canFavoriteEvents: boolean;
   canFavoriteRecordings: boolean;
@@ -102,8 +110,14 @@ interface BaseCapabilities {
   supportsTimeline: boolean;
 }
 
-export type CameraManagerCapabilities = BaseCapabilities;
-export type CameraManagerCameraCapabilities = BaseCapabilities;
+export interface CameraManagerCapabilities extends BaseCapabilities {
+  supportsPTZ: boolean;
+}
+
+export interface CameraManagerCameraCapabilities extends BaseCapabilities {
+  ptz?: PTZCapabilities;
+}
+
 export interface CameraManagerMediaCapabilities {
   canFavorite: boolean;
   canDownload: boolean;
@@ -131,8 +145,6 @@ export interface CameraEndpoints {
   jsmpeg?: CameraEndpoint;
   webrtcCard?: CameraEndpoint;
 }
-
-export type CameraConfigs = Map<string, CameraConfig>;
 
 export interface EngineOptions {
   useCache?: boolean;

--- a/src/card-controller/actions-manager.ts
+++ b/src/card-controller/actions-manager.ts
@@ -216,6 +216,22 @@ export class ActionsManager {
           .getViewManager()
           .setViewWithNewDisplayMode(frigateCardAction.display_mode);
         break;
+      case 'ptz':
+        const cameraID = this._api.getViewManager().getView()?.camera;
+        if (cameraID) {
+          this._api
+            .getCameraManager()
+            .executePTZAction(cameraID, frigateCardAction.ptz_action, {
+              phase: frigateCardAction.ptz_phase,
+              preset: frigateCardAction.ptz_preset,
+            });
+        }
+        break;
+      case 'show_ptz':
+        this._api
+          .getViewManager()
+          .setViewWithNewContext({ live: { ptzVisible: frigateCardAction.show_ptz } });
+        break;
       default:
         console.warn(`Frigate card received unknown card action: ${action}`);
     }

--- a/src/card-controller/initialization-manager.ts
+++ b/src/card-controller/initialization-manager.ts
@@ -13,7 +13,7 @@ export enum InitializationAspect {
 
 export class InitializationManager {
   protected _api: CardInitializerAPI;
-  protected _initializer;
+  protected _initializer: Initializer;
 
   constructor(api: CardInitializerAPI, initializer?: Initializer) {
     this._api = api;
@@ -21,11 +21,15 @@ export class InitializationManager {
   }
 
   public isInitializedMandatory(): boolean {
-    return this._initializer.isInitializedMultiple([
-      InitializationAspect.LANGUAGES,
-      InitializationAspect.SIDE_LOAD_ELEMENTS,
-      InitializationAspect.CAMERAS,
-    ]);
+    return (
+      this._initializer.isInitializedMultiple([
+        InitializationAspect.LANGUAGES,
+        InitializationAspect.SIDE_LOAD_ELEMENTS,
+        InitializationAspect.CAMERAS,
+      ]) &&
+      // If there's no view, re-initialize (e.g. config changes).
+      this._api.getViewManager().hasView()
+    );
   }
 
   /**
@@ -80,7 +84,6 @@ export class InitializationManager {
       }
     }
 
-    this._api.getCardElementManager().update();
     return true;
   }
 

--- a/src/card-controller/media-player-manager.ts
+++ b/src/card-controller/media-player-manager.ts
@@ -25,10 +25,10 @@ export class MediaPlayerManager {
     return this._mediaPlayers.length > 0;
   }
 
-  public async initialize(): Promise<void> {
+  public async initialize(): Promise<boolean> {
     const hass = this._api.getHASSManager().getHASS();
     if (!hass) {
-      return;
+      return false;
     }
 
     const isValidMediaPlayer = (entityID: string): boolean => {
@@ -66,6 +66,8 @@ export class MediaPlayerManager {
       const entity = mediaPlayerEntities?.get(entityID);
       return !entity || !entity.hidden_by;
     });
+
+    return true;
   }
 
   public async stop(mediaPlayer: string): Promise<void> {

--- a/src/card-controller/microphone-manager.ts
+++ b/src/card-controller/microphone-manager.ts
@@ -16,7 +16,7 @@ export class MicrophoneManager {
     this._api = api;
   }
 
-  public async connect(): Promise<void> {
+  public async connect(): Promise<boolean> {
     try {
       this._stream = await navigator.mediaDevices.getUserMedia({
         audio: true,
@@ -24,15 +24,19 @@ export class MicrophoneManager {
       });
     } catch (e: unknown) {
       errorToConsole(e as Error);
+
       this._stream = null;
+      this._api.getCardElementManager().update();
+      return false;
     }
     this._setMute();
+    return true;
   }
 
   public async disconnect(): Promise<void> {
     this._stream?.getTracks().forEach((track) => track.stop());
-    this._stream = undefined;
 
+    this._stream = undefined;
     this._api.getCardElementManager().update();
   }
 

--- a/src/card-controller/query-string-manager.ts
+++ b/src/card-controller/query-string-manager.ts
@@ -1,5 +1,5 @@
 import { FrigateCardCustomAction, FrigateCardViewAction } from '../config/types';
-import { createFrigateCardCustomAction } from '../utils/action.js';
+import { createFrigateCardCameraAction, createFrigateCardSimpleAction } from '../utils/action.js';
 import { CardQueryStringAPI } from './types';
 import { ViewManagerSetViewParameters } from './view-manager';
 
@@ -139,8 +139,7 @@ export class QueryStringManager {
         case 'camera_select':
         case 'live_substream_select':
           if (value) {
-            customAction = createFrigateCardCustomAction(action, {
-              camera: value,
+            customAction = createFrigateCardCameraAction(action, value, {
               cardID: cardID,
             });
           }
@@ -160,7 +159,7 @@ export class QueryStringManager {
         case 'snapshot':
         case 'snapshots':
         case 'timeline':
-          customAction = createFrigateCardCustomAction(action, {
+          customAction = createFrigateCardSimpleAction(action, {
             cardID: cardID,
           });
           break;

--- a/src/card-controller/triggers-manager.ts
+++ b/src/card-controller/triggers-manager.ts
@@ -28,8 +28,14 @@ export class TriggersManager {
     const now = new Date();
     let triggerChanges = false;
 
-    const cameras = this._api.getCameraManager().getStore().getVisibleCameras();
-    for (const [cameraID, config] of cameras?.entries()) {
+    const visibleCameraIDs = this._api
+      .getCameraManager()
+      .getStore()
+      .getVisibleCameraIDs();
+    for (const [cameraID, config] of this._api
+      .getCameraManager()
+      .getStore()
+      .getCameraConfigEntries(visibleCameraIDs)) {
       const triggerEntities = config.triggers.entities;
       const diffs = getHassDifferences(hass, oldHass, triggerEntities, {
         stateOnly: true,

--- a/src/card-controller/view-manager.ts
+++ b/src/card-controller/view-manager.ts
@@ -1,7 +1,6 @@
 import { ViewContext } from 'view';
 import { FrigateCardConfig, FrigateCardView, ViewDisplayMode } from '../config/types';
 import { View } from '../view/view';
-import { getAllDependentCameras } from '../utils/camera';
 import { log } from '../utils/debug';
 import { executeMediaQueryForView } from '../utils/media-to-view';
 import { CardViewAPI } from './types';
@@ -26,6 +25,10 @@ export class ViewManager {
 
   public getView(): View | null {
     return this._view;
+  }
+
+  public hasView(): boolean {
+    return !!this.getView();
   }
 
   public setView(view: View): void {
@@ -255,7 +258,7 @@ export class ViewManager {
 
   protected _createViewWithNextStream(baseView: View): View {
     const dependencies = [
-      ...getAllDependentCameras(this._api.getCameraManager(), baseView.camera),
+      ...this._api.getCameraManager().getStore().getAllDependentCameras(baseView.camera),
     ];
     if (dependencies.length <= 1) {
       return baseView.clone();

--- a/src/card.ts
+++ b/src/card.ts
@@ -163,6 +163,12 @@ class FrigateCard extends LitElement {
   }
 
   protected shouldUpdate(): boolean {
+    // Always allow messages to render, as a message may be generated during
+    // initialization.
+    if (this._controller.getMessageManager().hasMessage()) {
+      return true;
+    }
+
     if (!this._controller.getInitializationManager().isInitializedMandatory()) {
       this._controller.getInitializationManager().initializeMandatory();
       return false;
@@ -295,6 +301,12 @@ class FrigateCard extends LitElement {
               .view=${this._controller.getViewManager().getView()}
               .cameraManager=${cameraManager}
               .resolvedMediaCache=${this._controller.getResolvedMediaCache()}
+              .nonOverriddenConfig=${this._controller
+                .getConfigManager()
+                .getNonOverriddenConfig()}
+              .overriddenConfig=${this._controller.getConfigManager().getConfig()}
+              .cardWideConfig=${this._controller.getConfigManager().getCardWideConfig()}
+              .rawConfig=${this._controller.getConfigManager().getRawConfig()}
               .configManager=${this._controller.getConfigManager()}
               .conditionsManagerEpoch=${this._controller
                 .getConditionsManager()

--- a/src/components-lib/ptz-controller.ts
+++ b/src/components-lib/ptz-controller.ts
@@ -1,0 +1,170 @@
+import { HASSDomEvent, HomeAssistant } from '@dermotduffy/custom-card-helpers';
+import { CameraManager } from '../camera-manager/manager';
+import {
+  Actions,
+  ActionsConfig,
+  FrigateCardPTZAction,
+  FrigateCardPTZActions,
+  FrigateCardPTZConfig,
+  PTZAction,
+  PTZControlAction,
+  PTZ_CONTROL_ACTIONS,
+} from '../config/types';
+import {
+  frigateCardHandleActionConfig,
+  getActionConfigGivenAction,
+} from '../utils/action';
+
+export class PTZController {
+  private _host: HTMLElement;
+
+  private _config: FrigateCardPTZConfig | null = null;
+  private _hass: HomeAssistant | null = null;
+  private _cameraManager: CameraManager | null = null;
+  private _cameraID: string | null = null;
+  private _actions: FrigateCardPTZActions | null = null;
+  private _forceVisibility?: boolean;
+
+  constructor(host: HTMLElement) {
+    this._host = host;
+  }
+
+  public setConfig(config?: FrigateCardPTZConfig) {
+    this._config = config ?? null;
+
+    this._host.setAttribute('data-orientation', config?.orientation ?? 'horizontal');
+    this._host.setAttribute('data-position', config?.position ?? 'bottom-right');
+    this._host.setAttribute(
+      'style',
+      Object.entries(config?.style ?? {})
+        .map(([k, v]) => `${k}:${v}`)
+        .join(';'),
+    );
+  }
+
+  public getConfig(): FrigateCardPTZConfig | null {
+    return this._config;
+  }
+
+  public setHASS(hass?: HomeAssistant) {
+    this._hass = hass ?? null;
+  }
+
+  public setCamera(cameraManager?: CameraManager, cameraID?: string) {
+    this._cameraManager = cameraManager ?? null;
+    this._cameraID = cameraID ?? null;
+
+    this._calculateActions();
+  }
+
+  public setForceVisibility(forceVisibility?: boolean): void {
+    this._forceVisibility = forceVisibility;
+  }
+
+  public handleAction(
+    ev: HASSDomEvent<{ action: string }>,
+    config?: ActionsConfig | null,
+  ): void {
+    // Nothing else has the configuration for this action, so don't let it
+    // propagate further.
+    ev.stopPropagation();
+
+    const interaction: string = ev.detail.action;
+    const action = getActionConfigGivenAction(interaction, config);
+    if (config && action && this._hass) {
+      frigateCardHandleActionConfig(this._host, this._hass, config, interaction, action);
+    }
+  }
+
+  public getPTZActions(actionName: PTZControlAction): Actions | null {
+    const propertyName = 'actions_' + actionName;
+    return this._config?.[propertyName] ?? this._actions?.[propertyName] ?? null;
+  }
+
+  private _hasAnyAction(): boolean {
+    for (const actionName of PTZ_CONTROL_ACTIONS) {
+      if ('actions_' + actionName in (this._actions ?? {})) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public shouldDisplay(): boolean {
+    return this._forceVisibility === false
+      ? false
+      : this._config?.mode === 'on' && this._hasAnyAction();
+  }
+
+  private _calculateActions(): void {
+    const getDefaultAction = (
+      ptzAction: PTZAction,
+      options?: {
+        phase?: 'start' | 'stop';
+        preset?: string;
+      },
+    ): FrigateCardPTZAction => ({
+      action: 'fire-dom-event',
+      frigate_card_action: 'ptz',
+      ptz_action: ptzAction,
+      ...(options?.phase && { ptz_phase: options.phase }),
+      ...(options?.preset && { ptz_preset: options.preset }),
+    });
+
+    const getDefaultActions = (
+      ptzAction: PTZAction,
+      continuous: boolean,
+      preset?: string,
+    ): Actions =>
+      continuous
+        ? {
+            start_tap_action: getDefaultAction(ptzAction, {
+              phase: 'start',
+              preset: preset,
+            }),
+            end_tap_action: getDefaultAction(ptzAction, {
+              phase: 'stop',
+              preset: preset,
+            }),
+          }
+        : {
+            tap_action: getDefaultAction(ptzAction, { preset: preset }),
+          };
+
+    if (!this._cameraManager || !this._cameraID) {
+      return;
+    }
+
+    const ptzCapabilities = this._cameraManager.getCameraCapabilities(
+      this._cameraID,
+    )?.ptz;
+
+    const defaultActions: FrigateCardPTZActions = {};
+    const panTilt = ptzCapabilities?.panTilt;
+    const zoom = ptzCapabilities?.zoom;
+    const presets = ptzCapabilities?.presets;
+
+    if (panTilt?.length) {
+      const continuous = panTilt.includes('continuous');
+      defaultActions.actions_up = getDefaultActions('up', continuous);
+      defaultActions.actions_down = getDefaultActions('down', continuous);
+      defaultActions.actions_left = getDefaultActions('left', continuous);
+      defaultActions.actions_right = getDefaultActions('right', continuous);
+    }
+
+    if (zoom?.length) {
+      const continuous = zoom.includes('continuous');
+      defaultActions.actions_zoom_in = getDefaultActions('zoom_in', continuous);
+      defaultActions.actions_zoom_out = getDefaultActions('zoom_out', continuous);
+    }
+
+    if (presets?.length) {
+      defaultActions.actions_home = getDefaultActions('preset', false, presets[0]);
+    }
+
+    this._actions = {
+      ...defaultActions,
+      ...this._config,
+    };
+  }
+}

--- a/src/components/carousel.ts
+++ b/src/components/carousel.ts
@@ -69,7 +69,14 @@ export class FrigateCardCarousel extends LitElement {
       this.setAttribute('direction', this.direction);
     }
 
-    const destroyProperties = ['direction', 'dragFree', 'transitionEffect'] as const;
+    const destroyProperties = [
+      'direction',
+      'dragEnabled',
+      'dragFree',
+      'loop',
+      'plugins',
+      'transitionEffect',
+    ] as const;
     if (destroyProperties.some((prop) => changedProps.has(prop))) {
       this._carousel?.destroy();
       this._carousel = null;

--- a/src/components/media-filter.ts
+++ b/src/components/media-filter.ts
@@ -167,8 +167,8 @@ class FrigateCardMediaFilter extends ScopedRegistryHost(LitElement) {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _ev: CustomEvent<{ value: unknown }>,
   ): Promise<void> {
-    const cameras = this.cameraManager?.getStore().getVisibleCameras();
-    if (!this.hass || !cameras || !this.cameraManager || !this.view) {
+    const visibleCameraIDs = this.cameraManager?.getStore().getVisibleCameraIDs();
+    if (!this.hass || !visibleCameraIDs || !this.cameraManager || !this.view) {
       return;
     }
 
@@ -182,7 +182,7 @@ class FrigateCardMediaFilter extends ScopedRegistryHost(LitElement) {
     };
 
     const cameraIDs =
-      getArrayValueAsSet(this._refCamera.value?.value) ?? new Set(cameras.keys());
+      getArrayValueAsSet(this._refCamera.value?.value) ?? visibleCameraIDs;
     const mediaType = this._refMediaType.value?.value as
       | MediaFilterMediaType
       | undefined;
@@ -268,9 +268,9 @@ class FrigateCardMediaFilter extends ScopedRegistryHost(LitElement) {
 
   protected willUpdate(changedProps: PropertyValues): void {
     if (changedProps.has('cameraManager')) {
-      const cameras = this.cameraManager?.getStore().getVisibleCameras();
+      const cameras = this.cameraManager?.getStore().getVisibleCameraIDs();
       if (cameras) {
-        this._cameraOptions = Array.from(cameras.keys()).map((cameraID) => ({
+        this._cameraOptions = [...cameras].map((cameraID) => ({
           value: cameraID,
           label: this.hass
             ? this.cameraManager?.getCameraMetadata(cameraID)?.title ?? ''
@@ -319,8 +319,8 @@ class FrigateCardMediaFilter extends ScopedRegistryHost(LitElement) {
 
   protected _getDefaultsFromView(): MediaFilterCoreDefaults | null {
     const queries = this.view?.query?.getQueries();
-    const cameras = this.cameraManager?.getStore().getVisibleCameras();
-    if (!this.view || !queries || !cameras) {
+    const visibleCameraIDs = this.cameraManager?.getStore().getVisibleCameraIDs();
+    if (!this.view || !queries || !visibleCameraIDs) {
       return null;
     }
 
@@ -337,7 +337,7 @@ class FrigateCardMediaFilter extends ScopedRegistryHost(LitElement) {
     );
     // Special note: If all visible cameras are selected, this is the same as no
     // selector at all.
-    if (cameraIDSets.length === 1 && !isEqual(queries[0].cameraIDs, cameras)) {
+    if (cameraIDSets.length === 1 && !isEqual(queries[0].cameraIDs, visibleCameraIDs)) {
       cameraIDs = [...queries[0].cameraIDs];
     }
 

--- a/src/components/menu.ts
+++ b/src/components/menu.ts
@@ -97,7 +97,7 @@ export class FrigateCardMenu extends LitElement {
    * @param action The action to check.
    * @returns `true` if the action toggles the menu, `false` otherwise.
    */
-  protected _isMenuToggleAction(action: ActionType | undefined): boolean {
+  protected _isMenuToggleAction(action: ActionType | null): boolean {
     // Determine if this action is a Frigate card action, if so handle it
     // internally.
     if (!action) {

--- a/src/components/ptz.ts
+++ b/src/components/ptz.ts
@@ -1,0 +1,131 @@
+import { HASSDomEvent, HomeAssistant } from '@dermotduffy/custom-card-helpers';
+import {
+  CSSResultGroup,
+  html,
+  LitElement,
+  PropertyValues,
+  TemplateResult,
+  unsafeCSS
+} from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+import { actionHandler } from '../action-handler-directive.js';
+import { CameraManager } from '../camera-manager/manager.js';
+import { PTZController } from '../components-lib/ptz-controller.js';
+import { Actions, FrigateCardPTZConfig } from '../config/types.js';
+import { localize } from '../localize/localize.js';
+import ptzStyle from '../scss/ptz.scss';
+import { frigateCardHasAction } from '../utils/action.js';
+
+@customElement('frigate-card-ptz')
+export class FrigateCardPTZ extends LitElement {
+  @property({ attribute: false })
+  public hass?: HomeAssistant;
+
+  @property({ attribute: false })
+  public config?: FrigateCardPTZConfig;
+
+  @property({ attribute: false })
+  public cameraManager?: CameraManager;
+
+  @property({ attribute: false })
+  public cameraID?: string;
+
+  @property({ attribute: false })
+  public forceVisibility?: boolean;
+
+  protected _controller = new PTZController(this);
+
+  protected willUpdate(changedProps: PropertyValues): void {
+    if (changedProps.has('config')) {
+      this._controller.setConfig(this.config);
+    }
+    if (changedProps.has('hass')) {
+      this._controller.setHASS(this.hass);
+    }
+    if (changedProps.has('cameraManager') || changedProps.has('cameraID')) {
+      this._controller.setCamera(this.cameraManager, this.cameraID);
+    }
+    if (changedProps.has('forceVisibility')) {
+      this._controller.setForceVisibility(this.forceVisibility);
+    }
+  }
+
+  protected render(): TemplateResult | void {
+    if (!this._controller.shouldDisplay()) {
+      return;
+    }
+
+    const renderIcon = (
+      name: string,
+      icon: string,
+      actions: Actions | null,
+    ): TemplateResult => {
+      const classes = {
+        [name]: true,
+        disabled: !actions,
+      };
+
+      return html`<ha-icon
+        class=${classMap(classes)}
+        icon=${icon}
+        .actionHandler=${actionHandler({
+          hasHold: frigateCardHasAction(actions?.hold_action),
+          hasDoubleClick: frigateCardHasAction(actions?.double_tap_action),
+        })}
+        .title=${localize(`elements.ptz.${name}`)}
+        @action=${(ev: HASSDomEvent<{ action: string }>) =>
+          this._controller.handleAction(ev, actions)}
+      ></ha-icon>`;
+    };
+
+    const config = this._controller.getConfig();
+    const actionsZoomIn = this._controller.getPTZActions('zoom_in');
+    const actionsZoomOut = this._controller.getPTZActions('zoom_out');
+    const actionsHome = this._controller.getPTZActions('home');
+
+    return html` <div class="ptz">
+      ${!config?.hide_pan_tilt
+        ? html`<div class="ptz-move">
+            ${renderIcon(
+              'right',
+              'mdi:arrow-right',
+              this._controller.getPTZActions('right'),
+            )}
+            ${renderIcon(
+              'left',
+              'mdi:arrow-left',
+              this._controller.getPTZActions('left'),
+            )}
+            ${renderIcon('up', 'mdi:arrow-up', this._controller.getPTZActions('up'))}
+            ${renderIcon(
+              'down',
+              'mdi:arrow-down',
+              this._controller.getPTZActions('down'),
+            )}
+          </div>`
+        : ''}
+      ${!config?.hide_zoom && (actionsZoomIn || actionsZoomOut)
+        ? html` <div class="ptz-zoom">
+            ${renderIcon('zoom_in', 'mdi:plus', actionsZoomIn)}
+            ${renderIcon('zoom_out', 'mdi:minus', actionsZoomOut)}
+          </div>`
+        : html``}
+      ${!config?.hide_home && actionsHome
+        ? html`
+            <div class="ptz-home">${renderIcon('home', 'mdi:home', actionsHome)}</div>
+          `
+        : html``}
+    </div>`;
+  }
+
+  static get styles(): CSSResultGroup {
+    return unsafeCSS(ptzStyle);
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'frigate-card-ptz': FrigateCardPTZ;
+  }
+}

--- a/src/components/surround.ts
+++ b/src/components/surround.ts
@@ -16,7 +16,6 @@ import {
 import basicBlockStyle from '../scss/basic-block.scss';
 import { ClipsOrSnapshotsOrAll, ExtendedHomeAssistant } from '../types.js';
 import { contentsChanged, dispatchFrigateCardEvent } from '../utils/basic.js';
-import { getAllDependentCameras } from '../utils/camera.js';
 import { changeViewToRecentEventsForCameraAndDependents } from '../utils/media-to-view';
 import { View } from '../view/view.js';
 import './surround-basic.js';
@@ -140,7 +139,8 @@ export class FrigateCardSurround extends LitElement {
     if (this.view?.is('live')) {
       return this.view.isGrid()
         ? this.cameraManager?.getStore().getVisibleCameraIDs() ?? null
-        : getAllDependentCameras(this.cameraManager, this.view.camera);
+        : this.cameraManager?.getStore().getAllDependentCameras(this.view.camera) ??
+            null;
     }
     if (this.view.isViewerView()) {
       return this.view.query?.getQueryCameraIDs() ?? null;

--- a/src/components/thumbnail-carousel.ts
+++ b/src/components/thumbnail-carousel.ts
@@ -15,6 +15,7 @@ import { ExtendedHomeAssistant } from '../types.js';
 import { stopEventFromActivatingCardWideActions } from '../utils/action.js';
 import { dispatchFrigateCardEvent } from '../utils/basic.js';
 import { CarouselDirection } from '../utils/embla/carousel-controller.js';
+import AutoSize from '../utils/embla/plugins/auto-size/auto-size.js';
 import { MediaQueriesResults } from '../view/media-queries-results';
 import { View } from '../view/view.js';
 import './carousel.js';
@@ -136,6 +137,7 @@ export class FrigateCardThumbnailCarousel extends LitElement {
 
     return html`<frigate-card-carousel
       direction=${direction}
+      .plugins=${[AutoSize()]}
       .selected=${this._getSelectedSlide() ?? 0}
       .dragFree=${true}
     >

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -832,9 +832,6 @@ export const frigateCardPTZSchema = z.preprocess(
     return out;
   },
   frigateCardPTZActions.extend({
-    // TODO strip from config update
-    // type: z.literal('custom:frigate-card-ptz'),
-
     mode: z.enum(['off', 'on']).default(livePTZControlsDefaults.mode),
     position: z
       .enum(['top-left', 'top-right', 'bottom-left', 'bottom-right'])

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -65,6 +65,19 @@ const MEDIA_ACTION_POSITIVE_CONDITIONS = [
 export type AutoUnmuteCondition = (typeof MEDIA_ACTION_POSITIVE_CONDITIONS)[number];
 export type AutoPlayCondition = (typeof MEDIA_ACTION_POSITIVE_CONDITIONS)[number];
 
+const PTZ_BASE_ACTIONS = ['left', 'right', 'up', 'down', 'zoom_in', 'zoom_out'] as const;
+
+// PTZ actions as used by the PTZ control (includes a 'home' button).
+export const PTZ_CONTROL_ACTIONS = [...PTZ_BASE_ACTIONS, 'home'] as const;
+export type PTZControlAction = (typeof PTZ_CONTROL_ACTIONS)[number];
+
+// PTZ actions as used by the camera manager (includes generic presets).
+const PTZ_ACTIONS = [...PTZ_BASE_ACTIONS, 'preset'] as const;
+export type PTZAction = (typeof PTZ_ACTIONS)[number];
+
+const PTZ_PHASES = ['start', 'stop'] as const;
+export type PTZPhase = (typeof PTZ_PHASES)[number];
+
 // *************************************************************************
 //                        View Display Mode
 // *************************************************************************
@@ -201,31 +214,21 @@ const FRIGATE_CARD_GENERAL_ACTIONS = [
   'camera_ui',
   'default',
   'diagnostics',
-  'expand',
   'download',
+  'expand',
   'fullscreen',
-  'menu_toggle',
-  'mute',
-  'live_substream_on',
   'live_substream_off',
+  'live_substream_on',
+  'menu_toggle',
   'microphone_mute',
   'microphone_unmute',
-  'play',
+  'mute',
   'pause',
+  'play',
   'screenshot',
   'unmute',
 ] as const;
 export type FrigateCardGeneralAction = (typeof FRIGATE_CARD_GENERAL_ACTIONS)[number];
-
-const FRIGATE_CARD_ACTIONS = [
-  ...FRIGATE_CARD_VIEWS_USER_SPECIFIED,
-  ...FRIGATE_CARD_GENERAL_ACTIONS,
-  'camera_select',
-  'live_substream_select',
-  'media_player',
-  'display_mode_select',
-] as const;
-export type FrigateCardAction = (typeof FRIGATE_CARD_ACTIONS)[number];
 
 const frigateCardViewActionSchema = frigateCardCustomActionsBaseSchema.extend({
   frigate_card_action: z.enum(FRIGATE_CARD_VIEWS_USER_SPECIFIED),
@@ -240,9 +243,6 @@ const frigateCardCameraSelectActionSchema = frigateCardCustomActionsBaseSchema.e
   frigate_card_action: z.literal('camera_select'),
   camera: z.string(),
 });
-export type FrigateCardCameraSelectAction = z.infer<
-  typeof frigateCardCameraSelectActionSchema
->;
 
 const frigateCardLiveDependencySelectActionSchema =
   frigateCardCustomActionsBaseSchema.extend({
@@ -263,6 +263,19 @@ const frigateCardViewDisplayModeActionSchema = frigateCardCustomActionsBaseSchem
   },
 );
 
+const frigateCardPTZActionSchema = frigateCardCustomActionsBaseSchema.extend({
+  frigate_card_action: z.literal('ptz'),
+  ptz_action: z.enum(PTZ_ACTIONS),
+  ptz_phase: z.enum(PTZ_PHASES).optional(),
+  ptz_preset: z.string().optional(),
+});
+export type FrigateCardPTZAction = z.infer<typeof frigateCardPTZActionSchema>;
+
+const frigateCardShowPTZActionSchema = frigateCardCustomActionsBaseSchema.extend({
+  frigate_card_action: z.literal('show_ptz'),
+  show_ptz: z.boolean(),
+});
+
 export const frigateCardCustomActionSchema = z.union([
   frigateCardViewActionSchema,
   frigateCardGeneralActionSchema,
@@ -270,6 +283,8 @@ export const frigateCardCustomActionSchema = z.union([
   frigateCardLiveDependencySelectActionSchema,
   frigateCardMediaPlayerActionSchema,
   frigateCardViewDisplayModeActionSchema,
+  frigateCardPTZActionSchema,
+  frigateCardShowPTZActionSchema,
 ]);
 export type FrigateCardCustomAction = z.infer<typeof frigateCardCustomActionSchema>;
 
@@ -481,52 +496,7 @@ export const frigateConditionalSchema = z.object({
   conditions: frigateCardConditionSchema,
   elements: z.lazy(() => pictureElementsSchema),
 });
-
 export type FrigateConditional = z.infer<typeof frigateConditionalSchema>;
-
-// *************************************************************************
-//                  Custom Element Configuration: PTZ
-// *************************************************************************
-
-export const frigateCardPTZSchema = z.preprocess(
-  // To avoid lots of YAML duplication, provide an easy way to just specify the
-  // service data as actions for each PTZ icon, and it will be preprocessed into
-  // the full form. This also provides compatability with the AlexIT/WebRTC PTZ
-  // configuration.
-  (data) => {
-    if (!data || typeof data !== 'object' || !data['service']) {
-      return data;
-    }
-    const out = { ...data };
-    ['left', 'right', 'up', 'down', 'zoom_in', 'zoom_out', 'home'].forEach((name) => {
-      if (`data_${name}` in data && !(`actions_${name}` in data)) {
-        out[`actions_${name}`] = {
-          tap_action: {
-            action: 'call-service',
-            service: data['service'],
-            data: data[`data_${name}`],
-          },
-        };
-        delete out[`data_${name}`];
-      }
-    });
-    return out;
-  },
-  z.object({
-    type: z.literal('custom:frigate-card-ptz'),
-    style: z.object({}).passthrough().optional(),
-    orientation: z.enum(['vertical', 'horizontal']).default('vertical').optional(),
-    service: z.string().optional(),
-    actions_left: actionsBaseSchema.optional(),
-    actions_right: actionsBaseSchema.optional(),
-    actions_up: actionsBaseSchema.optional(),
-    actions_down: actionsBaseSchema.optional(),
-    actions_zoom_in: actionsBaseSchema.optional(),
-    actions_zoom_out: actionsBaseSchema.optional(),
-    actions_home: actionsBaseSchema.optional(),
-  }),
-);
-export type FrigateCardPTZConfig = z.infer<typeof frigateCardPTZSchema>;
 
 // *************************************************************************
 //       Custom Element Configuration: Stock Picture Elements + Custom
@@ -540,7 +510,6 @@ const pictureElementSchema = z.union([
   menuSubmenuSchema,
   menuSubmenuSelectSchema,
   frigateConditionalSchema,
-  frigateCardPTZSchema,
   stateBadgeIconSchema,
   stateIconSchema,
   stateLabelSchema,
@@ -818,6 +787,73 @@ const jsmpegConfigSchema = z.object({
     .optional(),
 });
 
+const frigateCardPTZActions = z.object({
+  actions_left: actionsBaseSchema.optional(),
+  actions_right: actionsBaseSchema.optional(),
+  actions_up: actionsBaseSchema.optional(),
+  actions_down: actionsBaseSchema.optional(),
+  actions_zoom_in: actionsBaseSchema.optional(),
+  actions_zoom_out: actionsBaseSchema.optional(),
+  actions_home: actionsBaseSchema.optional(),
+});
+export type FrigateCardPTZActions = z.infer<typeof frigateCardPTZActions>;
+
+const livePTZControlsDefaults = {
+  orientation: 'horizontal' as const,
+  mode: 'on' as const,
+  hide_pan_tilt: false,
+  hide_zoom: false,
+  hide_home: false,
+  position: 'bottom-right' as const,
+};
+
+export const frigateCardPTZSchema = z.preprocess(
+  // To avoid lots of YAML duplication, provide an easy way to just specify the
+  // service data as actions for each PTZ icon, and it will be preprocessed into
+  // the full form. This also provides compatability with the AlexIT/WebRTC PTZ
+  // configuration.
+  (data) => {
+    if (!data || typeof data !== 'object' || !data['service']) {
+      return data;
+    }
+    const out = { ...data };
+    PTZ_CONTROL_ACTIONS.forEach((name) => {
+      if (`data_${name}` in data && !(`actions_${name}` in data)) {
+        out[`actions_${name}`] = {
+          tap_action: {
+            action: 'call-service',
+            service: data['service'],
+            data: data[`data_${name}`],
+          },
+        };
+        delete out[`data_${name}`];
+      }
+    });
+    return out;
+  },
+  frigateCardPTZActions.extend({
+    // TODO strip from config update
+    // type: z.literal('custom:frigate-card-ptz'),
+
+    mode: z.enum(['off', 'on']).default(livePTZControlsDefaults.mode),
+    position: z
+      .enum(['top-left', 'top-right', 'bottom-left', 'bottom-right'])
+      .default(livePTZControlsDefaults.position),
+
+    orientation: z
+      .enum(['vertical', 'horizontal'])
+      .default(livePTZControlsDefaults.orientation),
+
+    hide_pan_tilt: z.boolean().default(livePTZControlsDefaults.hide_pan_tilt),
+    hide_zoom: z.boolean().default(livePTZControlsDefaults.hide_zoom),
+    hide_home: z.boolean().default(livePTZControlsDefaults.hide_home),
+
+    service: z.string().optional(),
+    style: z.object({}).passthrough().optional(),
+  }),
+);
+export type FrigateCardPTZConfig = z.infer<typeof frigateCardPTZSchema>;
+
 const liveThumbnailControlsDefaults = {
   ...thumbnailControlsDefaults,
   media: 'all' as const,
@@ -842,6 +878,7 @@ const liveConfigDefault = {
       size: 48,
       style: 'chevrons' as const,
     },
+    ptz: livePTZControlsDefaults,
     thumbnails: liveThumbnailControlsDefaults,
     timeline: miniTimelineConfigDefault,
   },
@@ -872,6 +909,7 @@ const liveOverridableConfigSchema = z
             ),
           })
           .default(liveConfigDefault.controls.next_previous),
+        ptz: frigateCardPTZSchema.default(liveConfigDefault.controls.ptz),
         thumbnails: livethumbnailsControlSchema.default(
           liveConfigDefault.controls.thumbnails,
         ),
@@ -934,7 +972,7 @@ const castConfigDefault = {
   method: 'standard' as const,
 };
 
-export const castSchema = z.object({
+const castSchema = z.object({
   method: z.enum(['standard', 'dashboard']).default(castConfigDefault.method).optional(),
   dashboard: z
     .object({
@@ -1170,6 +1208,7 @@ const menuConfigDefault = {
     recordings: hiddenButtonDefault,
     screenshot: hiddenButtonDefault,
     display_mode: visibleButtonDefault,
+    ptz: hiddenButtonDefault,
   },
   button_size: 40,
 };
@@ -1220,6 +1259,7 @@ const menuConfigSchema = z
         display_mode: visibleButtonSchema.default(
           menuConfigDefault.buttons.display_mode,
         ),
+        ptz: hiddenButtonSchema.default(menuConfigDefault.buttons.ptz),
       })
       .default(menuConfigDefault.buttons),
     button_size: z.number().min(BUTTON_SIZE_MIN).default(menuConfigDefault.button_size),
@@ -1411,13 +1451,13 @@ const overridesSchema = z
 //                       Automation Configuration
 // *************************************************************************
 
-const automationActionSchema = actionSchema.array().optional();
+const automationActionSchema = actionSchema.array();
 export type AutomationActions = z.infer<typeof automationActionSchema>;
 
 const automationSchema = z.object({
   conditions: frigateCardConditionSchema,
-  actions: automationActionSchema,
-  actions_not: automationActionSchema,
+  actions: automationActionSchema.optional(),
+  actions_not: automationActionSchema.optional(),
 });
 export type Automation = z.infer<typeof automationSchema>;
 

--- a/src/const.ts
+++ b/src/const.ts
@@ -98,7 +98,7 @@ export const CONF_MEDIA_GALLERY_CONTROLS_THUMBNAILS_SHOW_TIMELINE_CONTROL =
 export const CONF_MEDIA_GALLERY_CONTROLS_THUMBNAILS_SIZE =
   `${CONF_MEDIA_GALLERY}.controls.thumbnails.size` as const;
 
-export const CONF_MEDIA_VIEWER = 'media_viewer' as const;
+const CONF_MEDIA_VIEWER = 'media_viewer' as const;
 export const CONF_MEDIA_VIEWER_AUTO_PLAY = `${CONF_MEDIA_VIEWER}.auto_play` as const;
 export const CONF_MEDIA_VIEWER_AUTO_PAUSE = `${CONF_MEDIA_VIEWER}.auto_pause` as const;
 export const CONF_MEDIA_VIEWER_AUTO_MUTE = `${CONF_MEDIA_VIEWER}.auto_mute` as const;
@@ -169,6 +169,17 @@ export const CONF_LIVE_CONTROLS_NEXT_PREVIOUS_STYLE =
   `${CONF_LIVE}.controls.next_previous.style` as const;
 export const CONF_LIVE_CONTROLS_NEXT_PREVIOUS_SIZE =
   `${CONF_LIVE}.controls.next_previous.size` as const;
+export const CONF_LIVE_CONTROLS_PTZ_HIDE_HOME =
+  `${CONF_LIVE}.controls.ptz.hide_home` as const;
+export const CONF_LIVE_CONTROLS_PTZ_HIDE_PAN_TILT =
+  `${CONF_LIVE}.controls.ptz.hide_pan_tilt` as const;
+export const CONF_LIVE_CONTROLS_PTZ_HIDE_ZOOM =
+  `${CONF_LIVE}.controls.ptz.hide_zoom` as const;
+export const CONF_LIVE_CONTROLS_PTZ_MODE = `${CONF_LIVE}.controls.ptz.mode` as const;
+export const CONF_LIVE_CONTROLS_PTZ_ORIENTATION =
+  `${CONF_LIVE}.controls.ptz.orientation` as const;
+export const CONF_LIVE_CONTROLS_PTZ_POSITION =
+  `${CONF_LIVE}.controls.ptz.position` as const;
 export const CONF_LIVE_CONTROLS_THUMBNAILS_MEDIA =
   `${CONF_LIVE}.controls.thumbnails.media` as const;
 export const CONF_LIVE_CONTROLS_THUMBNAILS_MODE =
@@ -257,17 +268,10 @@ export const CONF_MENU_STYLE = `${CONF_MENU}.style` as const;
 export const CONF_MENU_BUTTON_SIZE = `${CONF_MENU}.button_size` as const;
 export const CONF_MENU_BUTTONS = `${CONF_MENU}.buttons` as const;
 
-export const CONF_MENU_BUTTONS_CAMERAS = `${CONF_MENU}.buttons.cameras` as const;
-export const CONF_MENU_BUTTONS_CLIPS = `${CONF_MENU}.buttons.clips` as const;
-export const CONF_MENU_BUTTONS_DOWNLOAD = `${CONF_MENU}.buttons.download` as const;
 export const CONF_MENU_BUTTONS_FRIGATE = `${CONF_MENU}.buttons.frigate` as const;
 export const CONF_MENU_BUTTONS_CAMERA_UI = `${CONF_MENU}.buttons.camera_ui` as const;
-export const CONF_MENU_BUTTONS_FULLSCREEN = `${CONF_MENU}.buttons.fullscreen` as const;
-export const CONF_MENU_BUTTONS_IMAGE = `${CONF_MENU}.buttons.image` as const;
-export const CONF_MENU_BUTTONS_LIVE = `${CONF_MENU}.buttons.live` as const;
 export const CONF_MENU_BUTTONS_MEDIA_PLAYER =
   `${CONF_MENU}.buttons.media_player` as const;
-export const CONF_MENU_BUTTONS_SNAPSHOTS = `${CONF_MENU}.buttons.snapshots` as const;
 export const CONF_MENU_BUTTONS_TIMELINE = `${CONF_MENU}.buttons.timeline` as const;
 
 const CONF_DIMENSIONS = 'dimensions' as const;

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -80,6 +80,12 @@ import {
   CONF_LIVE_CONTROLS_BUILTIN,
   CONF_LIVE_CONTROLS_NEXT_PREVIOUS_SIZE,
   CONF_LIVE_CONTROLS_NEXT_PREVIOUS_STYLE,
+  CONF_LIVE_CONTROLS_PTZ_HIDE_HOME,
+  CONF_LIVE_CONTROLS_PTZ_HIDE_PAN_TILT,
+  CONF_LIVE_CONTROLS_PTZ_HIDE_ZOOM,
+  CONF_LIVE_CONTROLS_PTZ_MODE,
+  CONF_LIVE_CONTROLS_PTZ_ORIENTATION,
+  CONF_LIVE_CONTROLS_PTZ_POSITION,
   CONF_LIVE_CONTROLS_THUMBNAILS_MEDIA,
   CONF_LIVE_CONTROLS_THUMBNAILS_MODE,
   CONF_LIVE_CONTROLS_THUMBNAILS_SHOW_DETAILS,
@@ -211,6 +217,7 @@ const MENU_CAMERAS_WEBRTC_CARD = 'cameras.webrtc_card';
 const MENU_IMAGE_LAYOUT = 'image.layout';
 const MENU_LIVE_CONTROLS = 'live.controls';
 const MENU_LIVE_CONTROLS_NEXT_PREVIOUS = 'live.controls.next_previous';
+const MENU_LIVE_CONTROLS_PTZ = 'live.controls.ptz';
 const MENU_LIVE_CONTROLS_THUMBNAILS = 'live.controls.thumbnails';
 const MENU_LIVE_CONTROLS_TIMELINE = 'live.controls.timeline';
 const MENU_LIVE_CONTROLS_TITLE = 'live.controls.title';
@@ -573,6 +580,45 @@ export class FrigateCardEditor extends LitElement implements LovelaceCardEditor 
     { value: '', label: '' },
     { value: 'standard', label: localize('config.cameras.cast.methods.standard') },
     { value: 'dashboard', label: localize('config.cameras.cast.methods.dashboard') },
+  ];
+
+  protected _ptzModes: EditorSelectOption[] = [
+    { value: '', label: '' },
+    { value: 'on', label: localize('config.live.controls.ptz.modes.on') },
+    { value: 'off', label: localize('config.live.controls.ptz.modes.off') },
+    { value: 'auto', label: localize('config.live.controls.ptz.modes.auto') },
+  ];
+
+  protected _ptzOrientations: EditorSelectOption[] = [
+    { value: '', label: '' },
+    {
+      value: 'vertical',
+      label: localize('config.live.controls.ptz.orientations.vertical'),
+    },
+    {
+      value: 'horizontal',
+      label: localize('config.live.controls.ptz.orientations.horizontal'),
+    },
+  ];
+
+  protected _ptzPositions: EditorSelectOption[] = [
+    { value: '', label: '' },
+    {
+      value: 'top-left',
+      label: localize('config.live.controls.ptz.positions.top-left'),
+    },
+    {
+      value: 'top-right',
+      label: localize('config.live.controls.ptz.positions.top-right'),
+    },
+    {
+      value: 'bottom-left',
+      label: localize('config.live.controls.ptz.positions.bottom-left'),
+    },
+    {
+      value: 'bottom-right',
+      label: localize('config.live.controls.ptz.positions.bottom-right'),
+    },
   ];
 
   public setConfig(config: RawFrigateCardConfig): void {
@@ -1886,6 +1932,8 @@ export class FrigateCardEditor extends LitElement implements LovelaceCardEditor 
                 ${this._renderMenuButton('play') /*  */}
                 ${this._renderMenuButton('mute') /*  */}
                 ${this._renderMenuButton('screenshot')}
+                ${this._renderMenuButton('display_mode')}
+                ${this._renderMenuButton('ptz')}
               </div>
             `
           : ''}
@@ -1980,6 +2028,47 @@ export class FrigateCardEditor extends LitElement implements LovelaceCardEditor 
                       CONF_LIVE_CONTROLS_TIMELINE_MEDIA,
                       CONF_LIVE_CONTROLS_TIMELINE_SHOW_RECORDINGS,
                       this._defaults.live.controls.timeline.show_recordings,
+                    )}
+                    ${this._putInSubmenu(
+                      MENU_LIVE_CONTROLS_PTZ,
+                      true,
+                      'config.live.controls.ptz.editor_label',
+                      { name: 'mdi:pan' },
+                      html`
+                        ${this._renderOptionSelector(
+                          CONF_LIVE_CONTROLS_PTZ_MODE,
+                          this._ptzModes,
+                        )}
+                        ${this._renderOptionSelector(
+                          CONF_LIVE_CONTROLS_PTZ_POSITION,
+                          this._ptzPositions,
+                        )}
+                        ${this._renderOptionSelector(
+                          CONF_LIVE_CONTROLS_PTZ_ORIENTATION,
+                          this._ptzOrientations,
+                        )}
+                        ${this._renderSwitch(
+                          CONF_LIVE_CONTROLS_PTZ_HIDE_PAN_TILT,
+                          this._defaults.live.controls.ptz.hide_pan_tilt,
+                          {
+                            label: localize('config.live.controls.ptz.hide_pan_tilt'),
+                          },
+                        )}
+                        ${this._renderSwitch(
+                          CONF_LIVE_CONTROLS_PTZ_HIDE_ZOOM,
+                          this._defaults.live.controls.ptz.hide_pan_tilt,
+                          {
+                            label: localize('config.live.controls.ptz.hide_zoom'),
+                          },
+                        )}
+                        ${this._renderSwitch(
+                          CONF_LIVE_CONTROLS_PTZ_HIDE_HOME,
+                          this._defaults.live.controls.ptz.hide_home,
+                          {
+                            label: localize('config.live.controls.ptz.hide_home'),
+                          },
+                        )}
+                      `,
                     )}
                   `,
                 )}

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -233,7 +233,31 @@
       "auto_play": "Automatically play live cameras",
       "auto_unmute": "Automatically unmute live cameras",
       "controls": {
-        "editor_label": "Live Controls"
+        "editor_label": "Live Controls",
+        "ptz": {
+          "editor_label": "PTZ",
+          "mode": "Mode",
+          "modes": {
+            "on": "On",
+            "off": "Off",
+            "auto": "Automatic"
+          },
+          "orientation": "Orientation",
+          "orientations": {
+            "vertical": "Vertical",
+            "horizontal": "Horizontal"
+          },
+          "position": "Position",
+          "positions": {
+            "top-left": "Top left",
+            "top-right": "Top right",
+            "bottom-left": "Bottom left",
+            "bottom-right": "Bottom right"
+          },
+          "hide_zoom": "Hide zoom control",
+          "hide_pan_tilt": "Hide pan & tilt control",
+          "hide_home": "Hide home control"
+        }
       },
       "draggable": "Live cameras view can be dragged/swiped",
       "layout": "Live Layout",
@@ -301,6 +325,7 @@
         "mute": "Mute / Unmute",
         "play": "Play / Pause",
         "priority": "Priority",
+        "ptz": "Show PTZ controls",
         "recordings": "Recordings",
         "screenshot": "Screenshot",
         "snapshots": "Snapshots",

--- a/src/localize/languages/it.json
+++ b/src/localize/languages/it.json
@@ -233,7 +233,31 @@
       "auto_play": "Gioca automaticamente le telecamere dal vivo",
       "auto_unmute": "Riattiva automaticamente l'audio delle telecamere live",
       "controls": {
-        "editor_label": "Controlli dal vivo"
+        "editor_label": "Controlli dal vivo",
+        "ptz": {
+          "editor_label": "",
+          "mode": "",
+          "modes": {
+            "on": "",
+            "off": "",
+            "auto": ""
+          },
+          "orientation": "",
+          "orientations": {
+            "vertical": "",
+            "horizontal": ""
+          },
+          "position": "",
+          "positions": {
+            "top-left": "",
+            "top-right": "",
+            "bottom-left": "",
+            "bottom-right": ""
+          },
+          "hide_zoom": "",
+          "hide_pan_tilt": "",
+          "hide_home": ""
+        }
       },
       "draggable": "Il Visualizzatore eventi può essere trascinato oppure puoi scorrere",
       "layout": "Disposizione dal vivo",
@@ -299,6 +323,7 @@
         "mute": "",
         "play": "",
         "priority": "Priorità",
+        "ptz": "",
         "screenshot": "",
         "snapshots": "Istantanee",
         "substreams": "Flusso/i secondario/i",

--- a/src/localize/languages/pt-BR.json
+++ b/src/localize/languages/pt-BR.json
@@ -233,7 +233,31 @@
       "auto_play": "Reproduzir câmeras ao vivo automaticamente",
       "auto_unmute": "Ativar automaticamente o som das câmeras ao vivo",
       "controls": {
-        "editor_label": "Controles da visualização ao vivo"
+        "editor_label": "Controles da visualização ao vivo",
+        "ptz": {
+          "editor_label": "",
+          "mode": "",
+          "modes": {
+            "on": "",
+            "off": "",
+            "auto": ""
+          },
+          "orientation": "",
+          "orientations": {
+            "vertical": "",
+            "horizontal": ""
+          },
+          "position": "",
+          "positions": {
+            "top-left": "",
+            "top-right": "",
+            "bottom-left": "",
+            "bottom-right": ""
+          },
+          "hide_zoom": "",
+          "hide_pan_tilt": "",
+          "hide_home": ""
+        }
       },
       "draggable": "A visualização ao vivo das câmeras pode ser arrastada/deslizada",
       "layout": "Layout dinâmico",
@@ -300,6 +324,7 @@
         "mute": "",
         "play": "",
         "priority": "Prioridade",
+        "ptz": "",
         "recordings": "Gravações",
         "screenshot": "",
         "snapshots": "Instantâneos",

--- a/src/localize/languages/pt-PT.json
+++ b/src/localize/languages/pt-PT.json
@@ -226,7 +226,31 @@
       "auto_play": "Reproduzir câmeras ao vivo automaticamente",
       "auto_unmute": "Ativar automaticamente o som das câmeras ao vivo",
       "controls": {
-        "editor_label": "Controles da visualização ao vivo"
+        "editor_label": "Controles da visualização ao vivo",
+        "ptz": {
+          "editor_label": "",
+          "mode": "",
+          "modes": {
+            "on": "",
+            "off": "",
+            "auto": ""
+          },
+          "orientation": "",
+          "orientations": {
+            "vertical": "",
+            "horizontal": ""
+          },
+          "position": "",
+          "positions": {
+            "top-left": "",
+            "top-right": "",
+            "bottom-left": "",
+            "bottom-right": ""
+          },
+          "hide_zoom": "",
+          "hide_pan_tilt": "",
+          "hide_home": ""
+        }
       },
       "draggable": "A visualização ao vivo das câmeras pode ser arrastada/deslizada",
       "layout": "layout",
@@ -292,6 +316,7 @@
         "mute": "",
         "play": "",
         "priority": "Prioridade",
+        "ptz": "",
         "screenshot": "",
         "snapshots": "Instantâneos",
         "substreams": "substreams",

--- a/src/localize/localize.ts
+++ b/src/localize/localize.ts
@@ -52,7 +52,7 @@ export function getLanguage(hass?: HomeAssistant): string {
 /**
  * Load required languages.
  */
-export const loadLanguages = async (hass: HomeAssistant): Promise<void> => {
+export const loadLanguages = async (hass: HomeAssistant): Promise<boolean> => {
   const lang = getLanguage(hass);
   if (lang === 'it') {
     languages[lang] = await import('./languages/it.json');
@@ -65,6 +65,7 @@ export const loadLanguages = async (hass: HomeAssistant): Promise<void> => {
   if (lang) {
     frigateCardLanguage = lang;
   }
+  return true;
 };
 
 /**

--- a/src/patches/ha-hls-player.ts
+++ b/src/patches/ha-hls-player.ts
@@ -12,11 +12,11 @@
 import { css, CSSResultGroup, html, TemplateResult, unsafeCSS } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { query } from 'lit/decorators/query.js';
-import { screenshotMedia } from '../utils/screenshot.js';
 import { dispatchErrorMessageEvent } from '../components/message.js';
 import liveHAComponentsStyle from '../scss/live-ha-components.scss';
 import { FrigateCardMediaPlayer } from '../types.js';
 import { mayHaveAudio } from '../utils/audio.js';
+import { errorToConsole } from '../utils/basic.js';
 import {
   dispatchMediaLoadedEvent,
   dispatchMediaPauseEvent,
@@ -26,6 +26,7 @@ import {
 import {
   hideMediaControlsTemporarily, MEDIA_LOAD_CONTROLS_HIDE_SECONDS, setControlsOnVideo
 } from '../utils/media.js';
+import { screenshotMedia } from '../utils/screenshot.js';
 
 customElements.whenDefined('ha-hls-player').then(() => {
   @customElement('frigate-card-ha-hls-player')
@@ -97,7 +98,7 @@ customElements.whenDefined('ha-hls-player').then(() => {
           // Use native Frigate card error handling for fatal errors.
           return dispatchErrorMessageEvent(this, this._error);
         } else {
-          console.error(this._error);
+          errorToConsole(this._error, console.error);
         }
       }
       return html`

--- a/src/scss/live-image.scss
+++ b/src/scss/live-image.scss
@@ -9,6 +9,5 @@ ha-icon {
   position: absolute;
   top: 10px;
   right: 10px;
-  opacity: 50%;
-  color: white;
+  color: var(--primary-color);
 }

--- a/src/scss/ptz.scss
+++ b/src/scss/ptz.scss
@@ -1,12 +1,25 @@
-// Modified from / inspired by:
+// Inspired by:
 // https://github.com/AlexxIT/WebRTC/blob/master/custom_components/webrtc/www/webrtc-camera.js
 :host {
-  position: relative;
+  position: absolute;
 
   width: fit-content;
   height: fit-content;
 
   --frigate-card-ptz-icon-size: 24px;
+}
+
+:host([data-position$='-left']) {
+  left: 5%;
+}
+:host([data-position$='-right']) {
+  right: 5%;
+}
+:host([data-position^='top-']) {
+  top: 5%;
+}
+:host([data-position^='bottom-']) {
+  bottom: 5%;
 }
 
 /*****************

--- a/src/utils/camera.ts
+++ b/src/utils/camera.ts
@@ -1,4 +1,3 @@
-import { CameraManager } from '../camera-manager/manager.js';
 import { CameraConfig, RawFrigateCardConfig } from '../config/types.js';
 
 /**
@@ -29,49 +28,4 @@ export function getCameraID(
       config.frigate['camera_name']) ||
     ''
   );
-}
-
-/**
- * Get all cameras that depend on a given camera.
- * @param cameraManager The camera manager.
- * @param cameraID ID of the target camera.
- * @returns A set of dependent cameraIDs or null (since JS sets guarantee order,
- * the first item in the set is guaranteed to be the cameraID itself).
- */
-export function getAllDependentCameras(
-  cameraManager: CameraManager,
-  cameraID: string,
-): Set<string>;
-export function getAllDependentCameras(
-  cameraManager?: CameraManager,
-  cameraID?: string,
-): Set<string> | null;
-export function getAllDependentCameras(
-  cameraManager?: CameraManager,
-  cameraID?: string,
-): Set<string> | null {
-  if (!cameraManager || !cameraID) {
-    return null;
-  }
-  const cameras = cameraManager.getStore().getCameras();
-
-  const cameraIDs: Set<string> = new Set();
-  const getDependentCameras = (cameraID: string): void => {
-    const cameraConfig = cameras.get(cameraID);
-    if (cameraConfig) {
-      cameraIDs.add(cameraID);
-      const dependentCameras: Set<string> = new Set();
-      cameraConfig.dependencies.cameras.forEach((item) => dependentCameras.add(item));
-      if (cameraConfig.dependencies.all_cameras) {
-        cameras.forEach((_, key) => dependentCameras.add(key));
-      }
-      for (const eventCameraID of dependentCameras) {
-        if (!cameraIDs.has(eventCameraID)) {
-          getDependentCameras(eventCameraID);
-        }
-      }
-    }
-  };
-  getDependentCameras(cameraID);
-  return cameraIDs;
 }

--- a/src/utils/initializer/initializer.ts
+++ b/src/utils/initializer/initializer.ts
@@ -5,7 +5,7 @@ enum InitializationState {
   INITIALIZED = 'initialized',
 }
 
-type InitializationCallback = () => Promise<unknown>;
+type InitializationCallback = () => Promise<boolean>;
 
 /**
  * Manages initialization state & calling initializers.
@@ -43,8 +43,11 @@ export class Initializer {
       if (state !== InitializationState.INITIALIZING) {
         if (initializer) {
           this._state.set(aspect, InitializationState.INITIALIZING);
-          await initializer();
-          this._state.set(aspect, InitializationState.INITIALIZED);
+          if (await initializer()) {
+            this._state.set(aspect, InitializationState.INITIALIZED);
+          } else {
+            this.uninitialize(aspect);
+          }
         } else {
           this._state.set(aspect, InitializationState.INITIALIZED);
         }

--- a/src/utils/media-to-view.ts
+++ b/src/utils/media-to-view.ts
@@ -14,7 +14,6 @@ import {
 import { MediaQueriesResults } from '../view/media-queries-results';
 import { View } from '../view/view';
 import { errorToConsole } from './basic';
-import { getAllDependentCameras } from './camera.js';
 
 type ResultSelectType = 'latest' | 'time' | 'none';
 
@@ -32,7 +31,7 @@ export const changeViewToRecentEventsForCameraAndDependents = async (
 ): Promise<void> => {
   const cameraIDs = options?.allCameras
     ? cameraManager.getStore().getVisibleCameraIDs()
-    : getAllDependentCameras(cameraManager, view.camera);
+    : cameraManager.getStore().getAllDependentCameras(view.camera);
   if (!cameraIDs.size) {
     return;
   }
@@ -98,7 +97,7 @@ export const changeViewToRecentRecordingForCameraAndDependents = async (
 ): Promise<void> => {
   const cameraIDs = options?.allCameras
     ? cameraManager.getStore().getVisibleCameraIDs()
-    : getAllDependentCameras(cameraManager, view.camera);
+    : cameraManager.getStore().getAllDependentCameras(view.camera);
   if (!cameraIDs.size) {
     return;
   }

--- a/src/utils/ptz.ts
+++ b/src/utils/ptz.ts
@@ -1,0 +1,14 @@
+import { CameraManagerCameraCapabilities } from '../camera-manager/types';
+import { FrigateCardPTZConfig, PTZ_CONTROL_ACTIONS } from '../config/types';
+
+export const hasUsablePTZ = (
+  capabilities: CameraManagerCameraCapabilities | null,
+  config: FrigateCardPTZConfig,
+): boolean => {
+  for (const actionName of PTZ_CONTROL_ACTIONS) {
+    if ('actions_' + actionName in config) {
+      return true;
+    }
+  }
+  return !!capabilities?.ptz;
+};

--- a/src/view/view.ts
+++ b/src/view/view.ts
@@ -5,6 +5,7 @@ import { dispatchFrigateCardEvent } from '../utils/basic.js';
 import { MediaQueries } from './media-queries';
 import { MediaQueriesClassifier } from './media-queries-classifier.js';
 import { MediaQueriesResults } from './media-queries-results';
+import merge from 'lodash-es/merge';
 
 interface ViewEvolveParameters {
   view?: FrigateCardView;
@@ -177,7 +178,7 @@ export class View {
    * @returns This view.
    */
   public mergeInContext(context?: ViewContext): View {
-    this.context = { ...this.context, ...context };
+    this.context = merge(this.context ?? {}, this.context, context);
     return this;
   }
 

--- a/tests/camera-manager/camera.test.ts
+++ b/tests/camera-manager/camera.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { Camera } from '../../src/camera-manager/camera.js';
+import { GenericCameraManagerEngine } from '../../src/camera-manager/generic/engine-generic.js';
+import { createCameraCapabilities, createCameraConfig } from '../test-utils.js';
+
+describe('Camera', () => {
+  it('should get config', async () => {
+    const config = createCameraConfig();
+    const camera = new Camera(
+      config,
+      new GenericCameraManagerEngine(),
+      createCameraCapabilities(),
+    );
+    expect(camera.getConfig()).toBe(config);
+  });
+
+  it('should get capabilities', async () => {
+    const capabilities = createCameraCapabilities();
+    const camera = new Camera(
+      createCameraConfig(),
+      new GenericCameraManagerEngine(),
+      capabilities,
+    );
+    expect(camera.getCapabilities()).toBe(capabilities);
+  });
+
+  it('should get engine', async () => {
+    const engine = new GenericCameraManagerEngine();
+    const camera = new Camera(createCameraConfig(), engine, createCameraCapabilities());
+    expect(camera.getEngine()).toBe(engine);
+  });
+
+  it('should set and get id', async () => {
+    const config = createCameraConfig();
+    const camera = new Camera(
+      config,
+      new GenericCameraManagerEngine(),
+      createCameraCapabilities(),
+    );
+    camera.setID('foo');
+    expect(camera.getID()).toBe('foo');
+    expect(camera.getConfig().id).toBe('foo');
+  });
+
+  it('should throw without id', async () => {
+    const config = createCameraConfig();
+    const camera = new Camera(
+      config,
+      new GenericCameraManagerEngine(),
+      createCameraCapabilities(),
+    );
+    expect(() => camera.getID()).toThrowError(
+      'Could not determine camera id for the following ' +
+        "camera, may need to set 'id' parameter manually",
+    );
+  });
+});

--- a/tests/camera-manager/frigate/requests.test.ts
+++ b/tests/camera-manager/frigate/requests.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  getEvents,
+  getEventSummary,
+  getPTZInfo,
+  getRecordingSegments,
+  getRecordingsSummary,
+  retainEvent,
+} from '../../../src/camera-manager/frigate/requests';
+import {
+  EventSummary,
+  eventSummarySchema,
+  FrigateEvent,
+  frigateEventsSchema,
+  ptzInfoSchema,
+  recordingSegmentsSchema,
+  recordingSummarySchema,
+  retainResultSchema,
+} from '../../../src/camera-manager/frigate/types';
+import { RecordingSegment } from '../../../src/camera-manager/types';
+import { homeAssistantWSRequest } from '../../../src/utils/ha';
+import { createFrigateEvent, createHASS } from '../../test-utils';
+
+vi.mock('../../../src/utils/ha');
+
+describe('frigate requests', () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+  it('should get recordings summary', async () => {
+    const recordingSummary = {
+      events: 0,
+      hours: [],
+      day: new Date(),
+    };
+    const hass = createHASS();
+    vi.mocked(homeAssistantWSRequest).mockResolvedValue(recordingSummary);
+    expect(await getRecordingsSummary(hass, 'clientID', 'camera.office')).toBe(
+      recordingSummary,
+    );
+    expect(homeAssistantWSRequest).toBeCalledWith(
+      hass,
+      recordingSummarySchema,
+      expect.objectContaining({
+        type: 'frigate/recordings/summary',
+        instance_id: 'clientID',
+        camera: 'camera.office',
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      }),
+      true,
+    );
+  });
+
+  it('should get recordings segments', async () => {
+    const recordingSegments: RecordingSegment[] = [
+      {
+        start_time: 0,
+        end_time: 1,
+        id: 'foo',
+      },
+    ];
+    const hass = createHASS();
+    vi.mocked(homeAssistantWSRequest).mockResolvedValue(recordingSegments);
+    expect(
+      await getRecordingSegments(hass, {
+        instance_id: 'clientID',
+        camera: 'camera.office',
+        after: 1,
+        before: 0,
+      }),
+    ).toBe(recordingSegments);
+    expect(homeAssistantWSRequest).toBeCalledWith(
+      hass,
+      recordingSegmentsSchema,
+      expect.objectContaining({
+        type: 'frigate/recordings/get',
+        instance_id: 'clientID',
+        camera: 'camera.office',
+        after: 1,
+        before: 0,
+      }),
+      true,
+    );
+  });
+
+  describe('should retain event', async () => {
+    it('successfully', async () => {
+      vi.mocked(homeAssistantWSRequest).mockResolvedValue({
+        success: true,
+        message: 'success',
+      });
+
+      const hass = createHASS();
+      retainEvent(hass, 'clientID', 'eventID', true);
+
+      expect(homeAssistantWSRequest).toBeCalledWith(
+        hass,
+        retainResultSchema,
+        expect.objectContaining({
+          type: 'frigate/event/retain',
+          instance_id: 'clientID',
+          event_id: 'eventID',
+          retain: true,
+        }),
+        true,
+      );
+    });
+
+    it('unsuccessfully', async () => {
+      vi.mocked(homeAssistantWSRequest).mockResolvedValue({
+        success: false,
+        message: 'failed',
+      });
+
+      const hass = createHASS();
+      await expect(retainEvent(hass, 'clientID', 'eventID', true)).rejects.toThrowError(
+        /Could not retain event/,
+      );
+      expect(homeAssistantWSRequest).toBeCalledWith(
+        hass,
+        retainResultSchema,
+        expect.objectContaining({
+          type: 'frigate/event/retain',
+          instance_id: 'clientID',
+          event_id: 'eventID',
+          retain: true,
+        }),
+        true,
+      );
+    });
+  });
+
+  it('should get events', async () => {
+    const events: FrigateEvent[] = [createFrigateEvent()];
+    const hass = createHASS();
+    vi.mocked(homeAssistantWSRequest).mockResolvedValue(events);
+    expect(
+      await getEvents(hass, {
+        instance_id: 'clientID',
+        cameras: ['camera.office'],
+        labels: ['person'],
+        zones: ['zone'],
+        after: 0,
+        before: 1,
+        limit: 10,
+        has_clip: true,
+        has_snapshot: true,
+        favorites: true,
+      }),
+    ).toBe(events);
+    expect(homeAssistantWSRequest).toBeCalledWith(
+      hass,
+      frigateEventsSchema,
+      expect.objectContaining({
+        type: 'frigate/events/get',
+        instance_id: 'clientID',
+        cameras: ['camera.office'],
+        labels: ['person'],
+        zones: ['zone'],
+        after: 0,
+        before: 1,
+        limit: 10,
+        has_clip: true,
+        has_snapshot: true,
+        favorites: true,
+      }),
+      true,
+    );
+  });
+
+  it('should get event summary', async () => {
+    const eventSummary: EventSummary = [
+      {
+        camera: 'camera.office',
+        day: '2023-10-29',
+        label: 'person',
+        sub_label: null,
+        zones: ['door'],
+      },
+    ];
+    const hass = createHASS();
+    vi.mocked(homeAssistantWSRequest).mockResolvedValue(eventSummary);
+    expect(await getEventSummary(hass, 'clientID')).toBe(eventSummary);
+    expect(homeAssistantWSRequest).toBeCalledWith(
+      hass,
+      eventSummarySchema,
+      expect.objectContaining({
+        type: 'frigate/events/summary',
+        instance_id: 'clientID',
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      }),
+      true,
+    );
+  });
+
+  it('should get PTZ info', async () => {
+    const ptzInfo = [
+      {
+        name: 'camera.office',
+        features: ['zoom', 'zoom-r'],
+        presets: ['preset01', 'preset02'],
+      },
+    ];
+    const hass = createHASS();
+    vi.mocked(homeAssistantWSRequest).mockResolvedValue(ptzInfo);
+    expect(await getPTZInfo(hass, 'clientID', 'camera.office')).toBe(ptzInfo);
+    expect(homeAssistantWSRequest).toBeCalledWith(
+      hass,
+      ptzInfoSchema,
+      expect.objectContaining({
+        type: 'frigate/ptz/info',
+        instance_id: 'clientID',
+        camera: 'camera.office',
+      }),
+      true,
+    );
+  });
+});

--- a/tests/card-controller/actions-manager.test.ts
+++ b/tests/card-controller/actions-manager.test.ts
@@ -23,7 +23,6 @@ import {
 } from '../test-utils';
 
 vi.mock('../../src/utils/action.js');
-vi.mock('../../src/camera-manager/manager.js');
 
 const createAction = (
   action: Record<string, unknown>,
@@ -706,6 +705,62 @@ describe('ActionsManager.executeAction', () => {
     );
 
     expect(api.getViewManager().setViewWithNewDisplayMode).toBeCalledWith('grid');
+  });
+
+  describe('should handle ptz action', () => {
+    it('with selected camera', async () => {
+      const api = createCardAPI();
+      const manager = new ActionsManager(api);
+      vi.mocked(api.getViewManager().getView).mockReturnValue(
+        createView({ camera: 'camera.office' }),
+      );
+
+      await manager.executeAction(
+        createAction({
+          frigate_card_action: 'ptz',
+          ptz_action: 'left',
+        })!,
+      );
+
+      expect(api.getCameraManager().executePTZAction).toBeCalledWith(
+        'camera.office',
+        'left',
+        {
+          phase: undefined,
+          preset: undefined,
+        },
+      );
+    });
+
+    it('without selected camera', async () => {
+      const api = createCardAPI();
+      const manager = new ActionsManager(api);
+
+      await manager.executeAction(
+        createAction({
+          frigate_card_action: 'ptz',
+          ptz_action: 'left',
+        })!,
+      );
+
+      expect(api.getCameraManager().executePTZAction).not.toBeCalled();
+    });
+  });
+
+  it('should handle show_ptz action', async () => {
+    const api = createCardAPI();
+    const manager = new ActionsManager(api);
+
+    await manager.executeAction(
+      createAction({
+        frigate_card_action: 'show_ptz',
+        show_ptz: true,
+      })!,
+    );
+
+    expect(api.getViewManager().setViewWithNewContext).toBeCalledWith(
+      expect.objectContaining({ live: { ptzVisible: true } }),
+    );
   });
 
   it('should handle unknown action', async () => {

--- a/tests/card-controller/hass-manager.test.ts
+++ b/tests/card-controller/hass-manager.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CardController } from '../../src/card-controller/controller';
 import { HASSManager } from '../../src/card-controller/hass-manager';
-import { CardHASSAPI } from '../../src/card-controller/types';
 import {
   createCameraConfig,
   createCameraManager,
@@ -8,12 +8,11 @@ import {
   createConfig,
   createHASS,
   createStateEntity,
+  createStore,
   createView,
 } from '../test-utils';
 
-vi.mock('../../src/camera-manager/manager.js');
-
-const createAPIWithoutMediaPlayers = (): CardHASSAPI => {
+const createAPIWithoutMediaPlayers = (): CardController => {
   const api = createCardAPI();
   vi.mocked(api.getMediaPlayerManager().getMediaPlayers).mockReturnValue([]);
   return api;
@@ -158,20 +157,20 @@ describe('HASSManager', () => {
 
   describe('should set default view when', () => {
     it('selected camera trigger entity changes', () => {
-      const cameraManager = createCameraManager({
-        configs: new Map([
-          [
-            'camera.foo',
-            createCameraConfig({
+      const api = createAPIWithoutMediaPlayers();
+      vi.mocked(api.getCameraManager).mockReturnValue(createCameraManager());
+      vi.mocked(api.getCameraManager().getStore).mockReturnValue(
+        createStore([
+          {
+            cameraID: 'camera.foo',
+            config: createCameraConfig({
               triggers: {
                 entities: ['binary_sensor.motion'],
               },
             }),
-          ],
+          },
         ]),
-      });
-      const api = createAPIWithoutMediaPlayers();
-      vi.mocked(api.getCameraManager).mockReturnValue(cameraManager);
+      );
       vi.mocked(api.getViewManager().getView).mockReturnValue(
         createView({
           camera: 'camera.foo',
@@ -189,20 +188,20 @@ describe('HASSManager', () => {
     });
 
     it('selected camera is unknown', () => {
-      const cameraManager = createCameraManager({
-        configs: new Map([
-          [
-            'camera.foo',
-            createCameraConfig({
+      const api = createAPIWithoutMediaPlayers();
+      vi.mocked(api.getCameraManager).mockReturnValue(createCameraManager());
+      vi.mocked(api.getCameraManager().getStore).mockReturnValue(
+        createStore([
+          {
+            cameraID: 'camera.foo',
+            config: createCameraConfig({
               triggers: {
                 entities: ['binary_sensor.motion'],
               },
             }),
-          ],
+          },
         ]),
-      });
-      const api = createAPIWithoutMediaPlayers();
-      vi.mocked(api.getCameraManager).mockReturnValue(cameraManager);
+      );
       vi.mocked(api.getViewManager().getView).mockReturnValue(
         createView({
           camera: 'camera.UNKNOWN',

--- a/tests/card-controller/initialization-manager.test.ts
+++ b/tests/card-controller/initialization-manager.test.ts
@@ -18,9 +18,37 @@ describe('InitializationManager', () => {
     vi.resetAllMocks();
   });
 
-  it('should not be initialized', () => {
-    const manager = new InitializationManager(createCardAPI());
-    expect(manager.isInitializedMandatory()).toBeFalsy();
+  describe('should correctly determine when mandatory initialization is required', () => {
+    it('without aspects', () => {
+      const api = createCardAPI();
+      const initializer = mock<Initializer>();
+      const manager = new InitializationManager(api, initializer);
+
+      initializer.isInitializedMultiple.mockReturnValue(false);
+
+      expect(manager.isInitializedMandatory()).toBeFalsy();
+    });
+
+    it('without view', () => {
+      const api = createCardAPI();
+      const initializer = mock<Initializer>();
+      const manager = new InitializationManager(api, initializer);
+
+      initializer.isInitializedMultiple.mockReturnValue(true);
+
+      expect(manager.isInitializedMandatory()).toBeFalsy();
+    });
+
+    it('with aspects and view', () => {
+      const api = createCardAPI();
+      const initializer = mock<Initializer>();
+      const manager = new InitializationManager(api, initializer);
+
+      initializer.isInitializedMultiple.mockReturnValue(true);
+      vi.mocked(api.getViewManager().hasView).mockReturnValue(true);
+
+      expect(manager.isInitializedMandatory()).toBeTruthy();
+    });
   });
 
   describe('should initialize mandatory', () => {
@@ -41,7 +69,9 @@ describe('InitializationManager', () => {
       vi.mocked(api.getHASSManager().getHASS).mockReturnValue(createHASS());
       vi.mocked(api.getConfigManager().hasConfig).mockReturnValue(true);
       vi.mocked(api.getMessageManager().hasMessage).mockReturnValue(false);
-      vi.mocked(api.getQueryStringManager().hasViewRelatedActions).mockReturnValue(false);
+      vi.mocked(api.getQueryStringManager().hasViewRelatedActions).mockReturnValue(
+        false,
+      );
       const manager = new InitializationManager(api);
 
       expect(await manager.initializeMandatory()).toBeTruthy();
@@ -50,7 +80,6 @@ describe('InitializationManager', () => {
       expect(sideLoadHomeAssistantElements).toBeCalled();
       expect(api.getCameraManager().initializeCamerasFromConfig).toBeCalled();
       expect(api.getViewManager().setViewDefault).toBeCalled();
-      expect(api.getCardElementManager().update).toBeCalled();
     });
 
     it('successfully with querystring view', async () => {
@@ -71,7 +100,9 @@ describe('InitializationManager', () => {
       vi.mocked(api.getHASSManager().getHASS).mockReturnValue(createHASS());
       vi.mocked(api.getConfigManager().hasConfig).mockReturnValue(true);
       vi.mocked(api.getMessageManager().hasMessage).mockReturnValue(true);
-      vi.mocked(api.getQueryStringManager().hasViewRelatedActions).mockReturnValue(false);
+      vi.mocked(api.getQueryStringManager().hasViewRelatedActions).mockReturnValue(
+        false,
+      );
       const manager = new InitializationManager(api);
 
       expect(await manager.initializeMandatory()).toBeTruthy();
@@ -134,7 +165,6 @@ describe('InitializationManager', () => {
       expect(await manager.initializeBackgroundIfNecessary()).toBeTruthy();
       expect(api.getMediaPlayerManager().initialize).not.toBeCalled();
       expect(api.getMicrophoneManager().connect).not.toBeCalled();
-      expect(api.getCardElementManager().update).not.toBeCalled();
     });
 
     it('successfully with all inititalizers', async () => {

--- a/tests/card-controller/microphone-manager.test.ts
+++ b/tests/card-controller/microphone-manager.test.ts
@@ -63,7 +63,7 @@ describe('MicrophoneManager', () => {
     const manager = new MicrophoneManager(api);
     navigatorMock.mediaDevices.getUserMedia.mockRejectedValue(new Error());
 
-    await manager.connect();
+    expect(await manager.connect()).toBeFalsy();
 
     expect(manager.isConnected()).toBeFalsy();
     expect(manager.isForbidden()).toBeTruthy();

--- a/tests/card-controller/triggers-manager.test.ts
+++ b/tests/card-controller/triggers-manager.test.ts
@@ -1,8 +1,9 @@
 import add from 'date-fns/add';
 import { HassEntities } from 'home-assistant-js-websocket';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { ScanOptions } from '../../src/config/types';
+import { CardController } from '../../src/card-controller/controller';
 import { TriggersManager } from '../../src/card-controller/triggers-manager';
+import { ScanOptions } from '../../src/config/types';
 import {
   createCameraConfig,
   createCameraManager,
@@ -10,10 +11,9 @@ import {
   createConfig,
   createHASS,
   createStateEntity,
+  createStore,
   createView,
 } from '../test-utils';
-
-vi.mock('../../src/camera-manager/manager.js');
 
 // Creating and mocking a trigger API is a lot of boilerplate, this convenience
 // function reduces it.
@@ -21,7 +21,7 @@ const createTriggerAPI = (options?: {
   config?: Partial<ScanOptions>;
   hassStates?: HassEntities;
   interaction?: boolean;
-}) => {
+}): CardController => {
   const api = createCardAPI();
   vi.mocked(api.getConfigManager().getConfig).mockReturnValue(
     createConfig({
@@ -37,19 +37,18 @@ const createTriggerAPI = (options?: {
   vi.mocked(api.getHASSManager().getHASS).mockReturnValue(
     createHASS(options?.hassStates),
   );
-  vi.mocked(api.getCameraManager).mockReturnValue(
-    createCameraManager({
-      configs: new Map([
-        [
-          'camera_1',
-          createCameraConfig({
-            triggers: {
-              entities: ['binary_sensor.motion'],
-            },
-          }),
-        ],
-      ]),
-    }),
+  vi.mocked(api.getCameraManager).mockReturnValue(createCameraManager());
+  vi.mocked(api.getCameraManager().getStore).mockReturnValue(
+    createStore([
+      {
+        cameraID: 'camera_1',
+        config: createCameraConfig({
+          triggers: {
+            entities: ['binary_sensor.motion'],
+          },
+        }),
+      },
+    ]),
   );
   vi.mocked(api.getInteractionManager().hasInteraction).mockReturnValue(
     options?.interaction ?? false,

--- a/tests/components-lib/ptz-controller.test.ts
+++ b/tests/components-lib/ptz-controller.test.ts
@@ -1,0 +1,316 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PTZController } from '../../src/components-lib/ptz-controller';
+import {
+  FrigateCardPTZConfig,
+  frigateCardPTZSchema,
+  PTZControlAction,
+} from '../../src/config/types';
+import {
+  frigateCardHandleActionConfig,
+  getActionConfigGivenAction,
+} from '../../src/utils/action.js';
+import {
+  createCameraCapabilities,
+  createCameraManager,
+  createHASS,
+} from '../test-utils';
+
+vi.mock('../../src/utils/action.js');
+
+const createConfig = (config?: Partial<FrigateCardPTZConfig>): FrigateCardPTZConfig => {
+  return frigateCardPTZSchema.parse({
+    ...config,
+  });
+};
+
+// @vitest-environment jsdom
+describe('PTZController', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should be creatable', () => {
+    const controller = new PTZController(document.createElement('div'));
+    expect(controller).toBeTruthy();
+  });
+
+  it('should get config creatable', () => {
+    const controller = new PTZController(document.createElement('div'));
+    const config = createConfig();
+    controller.setConfig(config);
+    expect(controller.getConfig()).toBe(config);
+  });
+
+  describe('should set element attributes', () => {
+    describe('orientation', () => {
+      describe('with config', () => {
+        it.each([['horizontal' as const], ['vertical' as const]])(
+          '%s',
+          (orientation: 'horizontal' | 'vertical') => {
+            const element = document.createElement('div');
+            const controller = new PTZController(element);
+            controller.setConfig(createConfig({ orientation: orientation }));
+            expect(element.getAttribute('data-orientation')).toBe(orientation);
+          },
+        );
+      });
+      it('without config', () => {
+        const element = document.createElement('div');
+        const controller = new PTZController(element);
+        controller.setConfig();
+        expect(element.getAttribute('data-orientation')).toBe('horizontal');
+      });
+    });
+    describe('position', () => {
+      describe('with config', () => {
+        it.each([
+          ['top-left' as const],
+          ['top-right' as const],
+          ['bottom-left' as const],
+          ['bottom-right' as const],
+        ])(
+          '%s',
+          (position: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right') => {
+            const element = document.createElement('div');
+            const controller = new PTZController(element);
+            controller.setConfig(createConfig({ position: position }));
+            expect(element.getAttribute('data-position')).toBe(position);
+          },
+        );
+      });
+      it('without config', () => {
+        const element = document.createElement('div');
+        const controller = new PTZController(element);
+        controller.setConfig();
+        expect(element.getAttribute('data-position')).toBe('bottom-right');
+      });
+    });
+    it('with style in config', () => {
+      const element = document.createElement('div');
+      const controller = new PTZController(element);
+      controller.setConfig(createConfig({ style: { transform: 'none', left: '50%' } }));
+      expect(element.getAttribute('style')).toBe('transform:none;left:50%');
+    });
+  });
+
+  describe('should respect mode', () => {
+    it('off', () => {
+      const controller = new PTZController(document.createElement('div'));
+      expect(controller.shouldDisplay()).toBeFalsy();
+    });
+    it('off but forced on', () => {
+      const controller = new PTZController(document.createElement('div'));
+      controller.setForceVisibility(true);
+      // No actions, no rendering, no matter what.
+      expect(controller.shouldDisplay()).toBeFalsy();
+    });
+    it('on without actions', () => {
+      const controller = new PTZController(document.createElement('div'));
+      controller.setConfig(createConfig({ mode: 'on' }));
+      expect(controller.shouldDisplay()).toBeFalsy();
+    });
+    it('on with actions', () => {
+      const controller = new PTZController(document.createElement('div'));
+      controller.setConfig(createConfig({ mode: 'on', actions_left: {} }));
+      controller.setCamera(createCameraManager(), 'camera.office');
+      expect(controller.shouldDisplay()).toBeTruthy();
+    });
+    it('on with actions but forced off', () => {
+      const controller = new PTZController(document.createElement('div'));
+      controller.setConfig(createConfig({ mode: 'on', actions_left: {} }));
+      controller.setCamera(createCameraManager(), 'camera.office');
+      controller.setForceVisibility(false);
+      expect(controller.shouldDisplay()).toBeFalsy();
+    });
+  });
+
+  describe('should get PTZ actions', () => {
+    it('without config', () => {
+      const controller = new PTZController(document.createElement('div'));
+      expect(controller.getPTZActions('left')).toBeNull();
+    });
+
+    describe('using defaults', () => {
+      describe('with continous PTZ', () => {
+        it.each([
+          ['left' as const],
+          ['right' as const],
+          ['up' as const],
+          ['down' as const],
+          ['zoom_in' as const],
+          ['zoom_out' as const],
+        ])('%s', (actionName: PTZControlAction) => {
+          const controller = new PTZController(document.createElement('div'));
+          controller.setConfig(createConfig());
+
+          const cameraManager = createCameraManager();
+          vi.mocked(cameraManager).getCameraCapabilities.mockReturnValue(
+            createCameraCapabilities({
+              ptz: {
+                panTilt: ['continuous'],
+                zoom: ['continuous'],
+              },
+            }),
+          );
+          controller.setCamera(cameraManager, 'camera.office');
+
+          expect(controller.getPTZActions(actionName)).toEqual({
+            start_tap_action: {
+              action: 'fire-dom-event',
+              frigate_card_action: 'ptz',
+              ptz_action: actionName,
+              ptz_phase: 'start',
+            },
+            end_tap_action: {
+              action: 'fire-dom-event',
+              frigate_card_action: 'ptz',
+              ptz_action: actionName,
+              ptz_phase: 'stop',
+            },
+          });
+        });
+      });
+
+      describe('with relative PTZ', () => {
+        it.each([
+          ['left' as const],
+          ['right' as const],
+          ['up' as const],
+          ['down' as const],
+          ['zoom_in' as const],
+          ['zoom_out' as const],
+        ])('%s', (actionName: PTZControlAction) => {
+          const controller = new PTZController(document.createElement('div'));
+          controller.setConfig(createConfig());
+
+          const cameraManager = createCameraManager();
+          vi.mocked(cameraManager).getCameraCapabilities.mockReturnValue(
+            createCameraCapabilities({
+              ptz: {
+                panTilt: ['relative'],
+                zoom: ['relative'],
+              },
+            }),
+          );
+          controller.setCamera(cameraManager, 'camera.office');
+
+          expect(controller.getPTZActions(actionName)).toEqual({
+            tap_action: {
+              action: 'fire-dom-event',
+              frigate_card_action: 'ptz',
+              ptz_action: actionName,
+            },
+          });
+        });
+      });
+
+      it('home', () => {
+        const controller = new PTZController(document.createElement('div'));
+        controller.setConfig(createConfig());
+
+        const cameraManager = createCameraManager();
+        vi.mocked(cameraManager).getCameraCapabilities.mockReturnValue(
+          createCameraCapabilities({
+            ptz: {
+              presets: ['preset-foo'],
+            },
+          }),
+        );
+        controller.setCamera(cameraManager, 'camera.office');
+
+        expect(controller.getPTZActions('home')).toEqual({
+          tap_action: {
+            action: 'fire-dom-event',
+            frigate_card_action: 'ptz',
+            ptz_action: 'preset',
+            ptz_preset: 'preset-foo',
+          },
+        });
+      });
+    });
+
+    describe('using config', () => {
+      it.each([
+        ['left' as const],
+        ['right' as const],
+        ['up' as const],
+        ['down' as const],
+        ['zoom_in' as const],
+        ['zoom_out' as const],
+      ])('%s', (actionName: PTZControlAction) => {
+        const controller = new PTZController(document.createElement('div'));
+        controller.setConfig(
+          createConfig({
+            [`actions_${actionName}`]: {
+              argument: actionName,
+            },
+          }),
+        );
+        controller.setCamera(createCameraManager(), 'camera.office');
+
+        expect(controller.getPTZActions(actionName)).toEqual({
+          argument: actionName,
+        });
+      });
+
+      it('home', () => {
+        const controller = new PTZController(document.createElement('div'));
+        controller.setConfig(
+          createConfig({
+            actions_home: {
+              argument: 'home',
+            },
+          }),
+        );
+        controller.setCamera(createCameraManager(), 'camera.office');
+
+        expect(controller.getPTZActions('home')).toEqual({
+          argument: 'home',
+        });
+      });
+    });
+  });
+
+  describe('should handle action', () => {
+    it('without hass or action', () => {
+      const controller = new PTZController(document.createElement('div'));
+      controller.setHASS();
+      controller.setCamera();
+      controller.handleAction(
+        new CustomEvent<{ action: string }>('@action', { detail: { action: 'tap' } }),
+      );
+      expect(frigateCardHandleActionConfig).not.toBeCalled();
+    });
+
+    it('with action', () => {
+      const element = document.createElement('div');
+      const controller = new PTZController(element);
+      const hass = createHASS();
+      controller.setHASS(hass);
+      controller.setConfig(
+        createConfig({
+          [`actions_left`]: {},
+        }),
+      );
+      const tapAction = {
+        action: 'none' as const,
+      };
+      const actionsConfig = {
+        tap_action: tapAction,
+      };
+      vi.mocked(getActionConfigGivenAction).mockReturnValue(tapAction);
+
+      controller.handleAction(
+        new CustomEvent<{ action: string }>('@action', { detail: { action: 'tap' } }),
+        actionsConfig,
+      );
+      expect(frigateCardHandleActionConfig).toBeCalledWith(
+        element,
+        hass,
+        actionsConfig,
+        'tap',
+        actionsConfig.tap_action,
+      );
+    });
+  });
+});

--- a/tests/config-mgmt.test.ts
+++ b/tests/config-mgmt.test.ts
@@ -739,4 +739,433 @@ describe('should handle version specific upgrades', () => {
       });
     });
   });
+
+  describe('should move PTZ elements to live', () => {
+    it('case with 1 element', () => {
+      const config = {
+        type: 'custom:frigate-card',
+        cameras: [{ camera_entity: 'camera.office' }],
+        elements: [
+          {
+            type: 'custom:frigate-card-ptz',
+            orientation: 'vertical',
+            style: {
+              right: '20px',
+              top: '20px',
+              color: 'white',
+            },
+            actions_up: {
+              tap_action: {
+                action: 'call-service',
+                service: 'notify.persistent_notification',
+                service_data: {
+                  message: 'Hello 1',
+                },
+              },
+            },
+          },
+        ],
+      };
+      expect(upgradeConfig(config)).toBeTruthy();
+      expect(config).toEqual({
+        cameras: [{ camera_entity: 'camera.office' }],
+        live: {
+          controls: {
+            ptz: {
+              actions_up: {
+                tap_action: {
+                  action: 'call-service',
+                  data: {
+                    message: 'Hello 1',
+                  },
+                  service: 'notify.persistent_notification',
+                },
+              },
+              orientation: 'vertical',
+              style: {
+                color: 'white',
+                right: '20px',
+                top: '20px',
+              },
+            },
+          },
+        },
+        type: 'custom:frigate-card',
+      });
+    });
+
+    it('case with >1 element', () => {
+      const config = {
+        type: 'custom:frigate-card',
+        cameras: [{ camera_entity: 'camera.office' }],
+        elements: [
+          {
+            type: 'custom:frigate-card-ptz',
+            orientation: 'vertical',
+            style: {
+              right: '20px',
+              top: '20px',
+              color: 'white',
+            },
+            actions_up: {
+              tap_action: {
+                action: 'call-service',
+                service: 'notify.persistent_notification',
+                service_data: {
+                  message: 'Hello 1',
+                },
+              },
+            },
+          },
+          {
+            type: 'service-button',
+            title: 'title',
+            service: 'service',
+            service_data: {
+              message: "It's a trick",
+            },
+          },
+        ],
+      };
+      expect(upgradeConfig(config)).toBeTruthy();
+      expect(config).toEqual({
+        cameras: [{ camera_entity: 'camera.office' }],
+        elements: [
+          {
+            service: 'service',
+            service_data: {
+              message: "It's a trick",
+            },
+            title: 'title',
+            type: 'service-button',
+          },
+        ],
+        live: {
+          controls: {
+            ptz: {
+              actions_up: {
+                tap_action: {
+                  action: 'call-service',
+                  data: {
+                    message: 'Hello 1',
+                  },
+                  service: 'notify.persistent_notification',
+                },
+              },
+              orientation: 'vertical',
+              style: {
+                color: 'white',
+                right: '20px',
+                top: '20px',
+              },
+            },
+          },
+        },
+        type: 'custom:frigate-card',
+      });
+    });
+
+    it('case with custom conditional element with 2 PTZ but nothing else', () => {
+      const config = {
+        type: 'custom:frigate-card',
+        cameras: [{ camera_entity: 'camera.office' }],
+        elements: [
+          {
+            type: 'custom:frigate-card-conditional',
+            conditions: {
+              fullscreen: true,
+              media_loaded: true,
+            },
+            elements: [
+              {
+                type: 'custom:frigate-card-ptz',
+                orientation: 'vertical',
+                style: {
+                  right: '20px',
+                  top: '20px',
+                  color: 'white',
+                },
+                actions_up: {
+                  tap_action: {
+                    action: 'call-service',
+                    service: 'notify.persistent_notification',
+                    service_data: {
+                      message: 'Hello 1',
+                    },
+                  },
+                },
+              },
+              {
+                type: 'custom:frigate-card-ptz',
+                orientation: 'vertical',
+                style: {
+                  right: '20px',
+                  top: '20px',
+                  color: 'white',
+                },
+                actions_up: {
+                  tap_action: {
+                    action: 'call-service',
+                    service: 'notify.persistent_notification',
+                    service_data: {
+                      message: 'Hello 2',
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      };
+      expect(upgradeConfig(config)).toBeTruthy();
+      expect(config).toEqual({
+        cameras: [{ camera_entity: 'camera.office' }],
+        live: {
+          controls: {
+            ptz: {
+              actions_up: {
+                tap_action: {
+                  action: 'call-service',
+                  data: {
+                    message: 'Hello 1',
+                  },
+                  service: 'notify.persistent_notification',
+                },
+              },
+              orientation: 'vertical',
+              style: {
+                color: 'white',
+                right: '20px',
+                top: '20px',
+              },
+            },
+          },
+        },
+        type: 'custom:frigate-card',
+      });
+    });
+
+    it('case with custom conditional element with 1 PTZ and another element', () => {
+      const config = {
+        type: 'custom:frigate-card',
+        cameras: [{ camera_entity: 'camera.office' }],
+        elements: [
+          {
+            type: 'custom:frigate-card-conditional',
+            conditions: {
+              fullscreen: true,
+              media_loaded: true,
+            },
+            elements: [
+              {
+                type: 'service-button',
+                title: 'title',
+                service: 'service',
+                service_data: {
+                  message: "It's a trick",
+                },
+              },
+              {
+                type: 'custom:frigate-card-ptz',
+                orientation: 'vertical',
+                style: {
+                  right: '20px',
+                  top: '20px',
+                  color: 'white',
+                },
+                actions_up: {
+                  tap_action: {
+                    action: 'call-service',
+                    service: 'notify.persistent_notification',
+                    service_data: {
+                      message: 'Hello 1',
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      };
+      expect(upgradeConfig(config)).toBeTruthy();
+      expect(config).toEqual({
+        cameras: [{ camera_entity: 'camera.office' }],
+        live: {
+          controls: {
+            ptz: {
+              actions_up: {
+                tap_action: {
+                  action: 'call-service',
+                  data: {
+                    message: 'Hello 1',
+                  },
+                  service: 'notify.persistent_notification',
+                },
+              },
+              orientation: 'vertical',
+              style: {
+                color: 'white',
+                right: '20px',
+                top: '20px',
+              },
+            },
+          },
+        },
+        elements: [
+          {
+            type: 'custom:frigate-card-conditional',
+            conditions: {
+              fullscreen: true,
+              media_loaded: true,
+            },
+            elements: [
+              {
+                type: 'service-button',
+                title: 'title',
+                service: 'service',
+                service_data: {
+                  message: "It's a trick",
+                },
+              },
+            ],
+          },
+        ],
+        type: 'custom:frigate-card',
+      });
+    });
+
+    it('case with stock conditional element with 1 PTZ', () => {
+      const config = {
+        type: 'custom:frigate-card',
+        cameras: [{ camera_entity: 'camera.office' }],
+        elements: [
+          {
+            type: 'conditional',
+            conditions: [{ entity: 'light.office', state: 'on' }],
+            elements: [
+              {
+                type: 'custom:frigate-card-ptz',
+                orientation: 'vertical',
+                style: {
+                  right: '20px',
+                  top: '20px',
+                  color: 'white',
+                },
+                actions_up: {
+                  tap_action: {
+                    action: 'call-service',
+                    service: 'notify.persistent_notification',
+                    service_data: {
+                      message: 'Hello 1',
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      };
+      expect(upgradeConfig(config)).toBeTruthy();
+      expect(config).toEqual({
+        cameras: [{ camera_entity: 'camera.office' }],
+        live: {
+          controls: {
+            ptz: {
+              actions_up: {
+                tap_action: {
+                  action: 'call-service',
+                  data: {
+                    message: 'Hello 1',
+                  },
+                  service: 'notify.persistent_notification',
+                },
+              },
+              orientation: 'vertical',
+              style: {
+                color: 'white',
+                right: '20px',
+                top: '20px',
+              },
+            },
+          },
+        },
+        type: 'custom:frigate-card',
+      });
+    });
+
+    it('case when live.controls.ptz already exists', () => {
+      const config = {
+        type: 'custom:frigate-card',
+        cameras: [{ camera_entity: 'camera.office' }],
+        live: {
+          controls: {
+            ptz: {
+              actions_up: {
+                tap_action: {
+                  action: 'call-service',
+                  data: {
+                    message: 'Original',
+                  },
+                  service: 'notify.persistent_notification',
+                },
+              },
+              orientation: 'vertical',
+              style: {
+                color: 'white',
+                right: '20px',
+                top: '20px',
+              },
+            },
+          },
+        },
+        elements: [
+          {
+            type: 'custom:frigate-card-ptz',
+            orientation: 'vertical',
+            style: {
+              right: '20px',
+              top: '20px',
+              color: 'white',
+            },
+            actions_up: {
+              tap_action: {
+                action: 'call-service',
+                service: 'notify.persistent_notification',
+                service_data: {
+                  message: 'Replacement that should be ignored',
+                },
+              },
+            },
+          },
+        ],
+      };
+      expect(upgradeConfig(config)).toBeTruthy();
+      expect(config).toEqual({
+        cameras: [{ camera_entity: 'camera.office' }],
+        live: {
+          controls: {
+            ptz: {
+              actions_up: {
+                tap_action: {
+                  action: 'call-service',
+                  data: {
+                    message: 'Original',
+                  },
+                  service: 'notify.persistent_notification',
+                },
+              },
+              orientation: 'vertical',
+              style: {
+                color: 'white',
+                right: '20px',
+                top: '20px',
+              },
+            },
+          },
+        },
+        type: 'custom:frigate-card',
+      });
+    });
+
+  });
 });

--- a/tests/config/types.test.ts
+++ b/tests/config/types.test.ts
@@ -68,6 +68,14 @@ describe('config defaults', () => {
             size: 48,
             style: 'chevrons',
           },
+          ptz: {
+            hide_home: false,
+            hide_pan_tilt: false,
+            hide_zoom: false,
+            mode: 'on',
+            orientation: 'horizontal',
+            position: 'bottom-right',
+          },
           thumbnails: {
             media: 'all',
             mode: 'right',
@@ -208,6 +216,10 @@ describe('config defaults', () => {
             enabled: false,
             priority: 50,
           },
+          ptz: {
+            enabled: false,
+            priority: 50,
+          },
           recordings: {
             enabled: false,
             priority: 50,
@@ -343,7 +355,13 @@ describe('should convert webrtc card PTZ to Frigate card PTZ', () => {
         },
       },
       service: 'foo',
-      type: 'custom:frigate-card-ptz',
+
+      hide_home: false,
+      hide_pan_tilt: false,
+      hide_zoom: false,
+      mode: 'on',
+      orientation: 'horizontal',
+      position: 'bottom-right',
     });
   });
 });

--- a/tests/utils/camera.test.ts
+++ b/tests/utils/camera.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
-import { mock } from 'vitest-mock-extended';
-import { CameraManager } from '../../src/camera-manager/manager.js';
-import { CameraConfigs } from '../../src/camera-manager/types.js';
-import { getAllDependentCameras, getCameraID } from '../../src/utils/camera.js';
-import { createCameraConfig, createCameraManager } from '../test-utils.js';
-
-vi.mock('../../src/camera-manager/manager.js');
+import { getCameraID } from '../../src/utils/camera.js';
+import { createCameraConfig } from '../test-utils.js';
 
 describe('getCameraID', () => {
   it('should get camera id with id', () => {
@@ -25,7 +20,9 @@ describe('getCameraID', () => {
     expect(getCameraID(config)).toBe('foo');
   });
   it('should get camera id with go2rtc url and stream', () => {
-    const config = createCameraConfig({ go2rtc: { url: 'https://foo', stream: 'office' } });
+    const config = createCameraConfig({
+      go2rtc: { url: 'https://foo', stream: 'office' },
+    });
     expect(getCameraID(config)).toBe('https://foo#office');
   });
   it('should get camera id with frigate camera_name', () => {
@@ -37,50 +34,5 @@ describe('getCameraID', () => {
   it('should get blank id without anything', () => {
     const config = createCameraConfig({});
     expect(getCameraID(config)).toBe('');
-  });
-});
-
-describe('getAllDependentCameras', () => {
-  it('should return null without cameraManager', () => {
-    expect(getAllDependentCameras()).toBeNull();
-  });
-  it('should return null without cameraID', () => {
-    expect(getAllDependentCameras(mock<CameraManager>())).toBeNull();
-  });
-  it('should return dependent cameras', () => {
-    const cameraConfigs: CameraConfigs = new Map([
-      [
-        'one',
-        createCameraConfig({
-          dependencies: {
-            cameras: ['two', 'three'],
-          },
-        }),
-      ],
-      ['two', createCameraConfig({})],
-    ]);
-
-    const cameraManager = createCameraManager({ configs: cameraConfigs });
-    expect(getAllDependentCameras(cameraManager, 'one')).toEqual(
-      new Set(['one', 'two']),
-    );
-  });
-  it('should return all cameras', () => {
-    const cameraConfigs: CameraConfigs = new Map([
-      [
-        'one',
-        createCameraConfig({
-          dependencies: {
-            all_cameras: true,
-          },
-        }),
-      ],
-      ['two', createCameraConfig({})],
-    ]);
-
-    const cameraManager = createCameraManager({ configs: cameraConfigs });
-    expect(getAllDependentCameras(cameraManager, 'one')).toEqual(
-      new Set(['one', 'two']),
-    );
   });
 });

--- a/tests/utils/diagnostics.test.ts
+++ b/tests/utils/diagnostics.test.ts
@@ -13,7 +13,6 @@ vi.mock('../../package.json', () => ({
     gitDate: 'Wed, 6 Sep 2023 21:27:28 -0700',
   },
 }));
-vi.mock('../../src/camera-manager/manager.js');
 vi.mock('../../src/utils/ha');
 vi.mock('../../src/localize/localize.js');
 vi.mock('../../src/utils/ha/device-registry');

--- a/tests/utils/download.test.ts
+++ b/tests/utils/download.test.ts
@@ -1,12 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { mock } from 'vitest-mock-extended';
-import { CameraManager } from '../../src/camera-manager/manager.js';
 import { downloadMedia, downloadURL } from '../../src/utils/download';
 import { homeAssistantSignPath } from '../../src/utils/ha';
 import { ViewMedia } from '../../src/view/media';
 import { createCameraManager, createHASS } from '../test-utils';
 
-vi.mock('../../src/camera-manager/manager.js');
 vi.mock('../../src/utils/ha');
 
 const media = new ViewMedia('clip', 'camera-1');
@@ -73,7 +71,7 @@ describe('downloadMedia', () => {
 
   it('should throw error when no media', () => {
     const cameraManager = createCameraManager();
-    mock<CameraManager>(cameraManager).getMediaDownloadPath.mockResolvedValue(null);
+    vi.mocked(cameraManager.getMediaDownloadPath).mockResolvedValue(null);
 
     expect(downloadMedia(createHASS(), cameraManager, media)).rejects.toThrow(
       /No media to download/,
@@ -84,7 +82,7 @@ describe('downloadMedia', () => {
     vi.spyOn(global.console, 'warn').mockReturnValue(undefined);
 
     const cameraManager = createCameraManager();
-    mock<CameraManager>(cameraManager).getMediaDownloadPath.mockResolvedValue({
+    vi.mocked(cameraManager).getMediaDownloadPath.mockResolvedValue({
       sign: true,
       endpoint: 'foo',
     });
@@ -98,7 +96,7 @@ describe('downloadMedia', () => {
 
   it('should download media', async () => {
     const cameraManager = createCameraManager();
-    mock<CameraManager>(cameraManager).getMediaDownloadPath.mockResolvedValue({
+    vi.mocked(cameraManager).getMediaDownloadPath.mockResolvedValue({
       sign: true,
       endpoint: 'foo',
     });
@@ -111,7 +109,7 @@ describe('downloadMedia', () => {
 
   it('should download media without signing', async () => {
     const cameraManager = createCameraManager();
-    mock<CameraManager>(cameraManager).getMediaDownloadPath.mockResolvedValue({
+    vi.mocked(cameraManager).getMediaDownloadPath.mockResolvedValue({
       sign: false,
       endpoint: 'https://foo/',
     });

--- a/tests/utils/ptz.test.ts
+++ b/tests/utils/ptz.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { FrigateCardPTZConfig, frigateCardPTZSchema } from '../../src/config/types';
+import { hasUsablePTZ } from '../../src/utils/ptz';
+import { createCameraCapabilities } from '../test-utils';
+
+const createPTZConfig = (
+  config?: Partial<FrigateCardPTZConfig>,
+): FrigateCardPTZConfig => {
+  return frigateCardPTZSchema.parse(config ?? {});
+};
+
+describe('hasUsablePTZ', () => {
+  it('should return true with manual actions', () => {
+    expect(
+      hasUsablePTZ(
+        createCameraCapabilities(),
+        createPTZConfig({
+          actions_left: {},
+        }),
+      ),
+    ).toBeTruthy();
+  });
+  it('should return true with capabilities', () => {
+    expect(
+      hasUsablePTZ(
+        createCameraCapabilities({
+          ptz: {},
+        }),
+        createPTZConfig(),
+      ),
+    ).toBeTruthy();
+  });
+  it('should return false with manual actions or capabilities', () => {
+    expect(hasUsablePTZ(createCameraCapabilities(), createPTZConfig())).toBeFalsy();
+  });
+});


### PR DESCRIPTION
* Closes #1163 
* Breaks existing PTZ controls by moving `custom:frigate-card-ptz` element into a normal part of the configuration (under `live`) -- auto-upgrade offered that should cover most (but not all) cases.
* Requires at least integration [v5.0.0-beta.3](https://github.com/blakeblackshear/frigate-hass-integration/releases/tag/v5.0.0-beta.3).