### PR TITLE
Add support for `user` and `numeric_state` conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ See the [fully expanded cameras configuration example](#config-expanded-cameras)
 
 #### Camera Frigate configuration
 
-The `frigate` block configures options for a Frigate camera. This configuration is included as part of a camera entry in the `cameras` array.
+The `frigate` block configures options for a Frigate camera. This configuration is included as part of a camera entry in the `cameras` list.
 
 ```yaml
 cameras:
@@ -197,13 +197,13 @@ cameras:
 | - | - | - | - |
 | `camera_name` | Autodetected from `camera_entity` if that is specified. | :white_check_mark: | The Frigate camera name to use when communicating with the Frigate server, e.g. for viewing clips/snapshots or the JSMPEG live view.|
 | `url` | | :white_check_mark: | The URL of the frigate server. If set, this value will be (exclusively) used for a `Camera UI` menu button. All other communication with Frigate goes via Home Assistant. |
-| `labels` | | :white_check_mark: | An array of Frigate labels used to filter events (clips & snapshots), e.g. [`person`, `car`].|
-| `zones` | | :white_check_mark: | An array of Frigates zones used to filter events (clips & snapshots), e.g. [`front_door`, `front_steps`].|
+| `labels` | | :white_check_mark: | A list of Frigate labels used to filter events (clips & snapshots), e.g. [`person`, `car`].|
+| `zones` | | :white_check_mark: | A list of Frigates zones used to filter events (clips & snapshots), e.g. [`front_door`, `front_steps`].|
 | `client_id` | `frigate` | :white_check_mark: | The Frigate client id to use. If this Home Assistant server has multiple Frigate server backends configured, this selects which server should be used. It should be set to the MQTT client id configured for this server, see [Frigate Integration Multiple Instance Support](https://docs.frigate.video/integrations/home-assistant/#multiple-instance-support).|
 
 #### Camera MotionEye configuration
 
-The `motioneye` block configures options for a MotionEye camera. This configuration is included as part of a camera entry in the `cameras` array.
+The `motioneye` block configures options for a MotionEye camera. This configuration is included as part of a camera entry in the `cameras` list.
 
 ```yaml
 cameras:
@@ -241,7 +241,7 @@ cameras:
 
 #### Live Provider: Camera go2rtc configuration
 
-The `go2rtc` block configures use of the `go2rtc` live provider. This configuration is included as part of a camera entry in the `cameras` array.
+The `go2rtc` block configures use of the `go2rtc` live provider. This configuration is included as part of a camera entry in the `cameras` list.
 
 ```yaml
 cameras:
@@ -250,7 +250,7 @@ cameras:
 
 | Option | Default | Overridable | Description |
 | - | - | - | - |
-| `modes` | `[webrtc, mse, mp4, mjpeg]` | :white_check_mark: | An ordered array of `go2rtc` modes to use. Valid values are `webrtc`, `mse`, `mp4` or `mjpeg` values. |
+| `modes` | `[webrtc, mse, mp4, mjpeg]` | :white_check_mark: | An ordered list of `go2rtc` modes to use. Valid values are `webrtc`, `mse`, `mp4` or `mjpeg` values. |
 | `stream` | Determined by camera engine (e.g. `frigate` camera name). | :white_check_mark: | A valid `go2rtc` stream name. |
 | `url` | Determined by camera engine (e.g. the `frigate` engine will automatically generate a URL for the go2rtc backend that runs in the Frigate container). | :white_check_mark: | The root `go2rtc` URL the card should stream the video from. This is only needed for non-Frigate usecases, or advanced Frigate usecases. Example: `http://my-custom-go2rtc:1984` |
 
@@ -314,7 +314,7 @@ cameras:
 
 | Option | Default | Overridable | Description |
 | - | - | - | - |
-| `cameras` | | :white_check_mark: | An optional array of other camera identifiers (see [camera IDs](#camera-ids)). If specified the card will fetch media for this camera and *also* recursively for the named cameras by default. Live views for the involved cameras will be available as 'substreams' of the main (depended upon) camera. All dependent cameras must themselves be a configured camera in the card. This can be useful to group events for cameras that are close together, to show multiple related live  views, to always have clips/snapshots show fully merged events across all cameras or to show events for the `birdseye` camera that otherwise would not have events itself.|
+| `cameras` | | :white_check_mark: | An optional list of other camera identifiers (see [camera IDs](#camera-ids)). If specified the card will fetch media for this camera and *also* recursively for the named cameras by default. Live views for the involved cameras will be available as 'substreams' of the main (depended upon) camera. All dependent cameras must themselves be a configured camera in the card. This can be useful to group events for cameras that are close together, to show multiple related live  views, to always have clips/snapshots show fully merged events across all cameras or to show events for the `birdseye` camera that otherwise would not have events itself.|
 | `all_cameras` | `false` | :white_check_mark: | Shortcut to specify all other cameras as dependent cameras.|
 
 <a name="camera-triggers-configuration"></a>
@@ -555,12 +555,12 @@ See the [fully expanded live configuration example](#config-expanded-live) for h
 | Option | Default | Overridable | Description |
 | - | - | - | - |
 | `preload` | `false` | :heavy_multiplication_x: | Whether or not to preload the live view. Preloading causes the live view to render in the background regardless of what view is actually shown, so it's instantly available when requested. This consumes additional network/CPU resources continually. |
-| `auto_play` | `[selected, visible]` | :heavy_multiplication_x: | An array of conditions in which live camera feeds are automatically played.`selected` will automatically play when a camera is selected in the carousel and `visible` will automatically play when the browser/tab becomes visible. Use an empty list (`[]`) to never automatically play. Some live providers (e.g. `webrtc-card`, `jsmpeg`) do not support the prevention of automatic play on initial load, but should still respect the value of this flag on play-after-pause.|
-| `auto_pause` | `[]` | :heavy_multiplication_x: | An array of conditions in which live camera feeds are automatically paused. `unselected` will automatically pause when a camera is unselected in the carousel and `hidden` will automatically pause when the browser/tab becomes hidden. Use an empty list (`[]`) to never automatically pause. **Caution**: Some live providers (e.g. `jsmpeg`) may not offer human-accessible means to resume play if it is paused, unless the `auto_play` option (above) is used.|
-| `auto_mute` | `[unselected, hidden, microphone]` | :heavy_multiplication_x: | An array of conditions in which live camera feeds are muted. `unselected` will automatically mute when a camera is unselected in the carousel, `hidden` will automatically mute when the browser/tab becomes hidden or `microphone` will automatically mute after the microphone is muted as long as the camera stays selected (see the `live.microphone.mute_after_microphone_mute_seconds` to control how long after). Use an empty list (`[]`) to never automatically mute. Note that if `auto_play` is enabled, the stream may mute itself automatically in order to honor the `auto_play` setting, as some browsers will not auto play media that is unmuted -- that is to say, where necessary, the `auto_play` parameter will take priority over the `auto_mute` parameter.|
-| `auto_unmute` | `[microphone]` | :heavy_multiplication_x: | An array of conditions in which live camera feeds are unmuted. `selected` will automatically unmute when a camera is unselected in the carousel, `visible` will automatically unmute when the browser/tab becomes visible or `microphone` will automatically unmute after the microphone is unmuted. Use an empty list (`[]`) to never automatically unmute.|
+| `auto_play` | `[selected, visible]` | :heavy_multiplication_x: | A list of conditions in which live camera feeds are automatically played.`selected` will automatically play when a camera is selected in the carousel and `visible` will automatically play when the browser/tab becomes visible. Use an empty list (`[]`) to never automatically play. Some live providers (e.g. `webrtc-card`, `jsmpeg`) do not support the prevention of automatic play on initial load, but should still respect the value of this flag on play-after-pause.|
+| `auto_pause` | `[]` | :heavy_multiplication_x: | A list of conditions in which live camera feeds are automatically paused. `unselected` will automatically pause when a camera is unselected in the carousel and `hidden` will automatically pause when the browser/tab becomes hidden. Use an empty list (`[]`) to never automatically pause. **Caution**: Some live providers (e.g. `jsmpeg`) may not offer human-accessible means to resume play if it is paused, unless the `auto_play` option (above) is used.|
+| `auto_mute` | `[unselected, hidden, microphone]` | :heavy_multiplication_x: | A list of conditions in which live camera feeds are muted. `unselected` will automatically mute when a camera is unselected in the carousel, `hidden` will automatically mute when the browser/tab becomes hidden or `microphone` will automatically mute after the microphone is muted as long as the camera stays selected (see the `live.microphone.mute_after_microphone_mute_seconds` to control how long after). Use an empty list (`[]`) to never automatically mute. Note that if `auto_play` is enabled, the stream may mute itself automatically in order to honor the `auto_play` setting, as some browsers will not auto play media that is unmuted -- that is to say, where necessary, the `auto_play` parameter will take priority over the `auto_mute` parameter.|
+| `auto_unmute` | `[microphone]` | :heavy_multiplication_x: | A list of conditions in which live camera feeds are unmuted. `selected` will automatically unmute when a camera is unselected in the carousel, `visible` will automatically unmute when the browser/tab becomes visible or `microphone` will automatically unmute after the microphone is unmuted. Use an empty list (`[]`) to never automatically unmute.|
 | `lazy_load` | `true` | :heavy_multiplication_x: | Whether or not to lazily load cameras in the camera carousel. Setting this will `false` will cause all cameras to load simultaneously when the `live` carousel is opened (or cause all cameras to load continually if both `lazy_load` and `preload` are `true`). This will result in a smoother carousel experience at a cost of (potentially) a substantial amount of continually streamed data. |
-| `lazy_unload` | `[]` | :heavy_multiplication_x: | An array of conditions in which live camera feeds are unloaded. `unselected` will lazy-unload a camera when it is unselected in the carousel and `hidden` will lazy-unload all cameras when the browser/tab becomes hidden. Use an empty list (`[]`) to never automatically unload. This will cause a reloading delay on revisiting that camera in the carousel but will save the streaming network resources that are otherwise consumed. This option has no effect if `lazy_load` is false. Some live providers (e.g. `webrtc-card`) implement their own lazy unloading independently which may occur regardless of the value of this setting.|
+| `lazy_unload` | `[]` | :heavy_multiplication_x: | A list of conditions in which live camera feeds are unloaded. `unselected` will lazy-unload a camera when it is unselected in the carousel and `hidden` will lazy-unload all cameras when the browser/tab becomes hidden. Use an empty list (`[]`) to never automatically unload. This will cause a reloading delay on revisiting that camera in the carousel but will save the streaming network resources that are otherwise consumed. This option has no effect if `lazy_load` is false. Some live providers (e.g. `webrtc-card`) implement their own lazy unloading independently which may occur regardless of the value of this setting.|
 | `draggable` | `true` | :heavy_multiplication_x: | Whether or not the live carousel can be dragged left or right, via touch/swipe and mouse dragging. |
 | `zoomable` | `true` | :white_check_mark: | Whether or not the live carousel can be zoomed and panned, via touch/pinch and mouse scroll wheel with `ctrl` held. |
 | `transition_effect` | `slide` | :heavy_multiplication_x: | Effect to apply as a transition between live cameras. Accepted values: `slide` or `none`. |
@@ -743,10 +743,10 @@ See the [fully expanded Media viewer configuration example](#config-expanded-med
 
 | Option | Default | Overridable | Description |
 | - | - | - | - |
-| `auto_play` | `[selected, visible]` | :heavy_multiplication_x: | An array of conditions in which media items are automatically played.`selected` will automatically play when a media item is selected in the carousel and `visible` will automatically play when the browser/tab becomes visible. Use an empty list (`[]`) to never automatically play.|
-| `auto_pause` | `[unselected, hidden]` | :heavy_multiplication_x: | An array of conditions in which media items are automatically paused. `unselected` will automatically pause when a media item is unselected in the carousel and `hidden` will automatically pause when the browser/tab becomes hidden. Use an empty list (`[]`) to never automatically pause.|
-| `auto_mute` | `[unselected, hidden]` | :heavy_multiplication_x: | An array of conditions in which media items are muted. `unselected` will automatically mute when a media item is unselected in the carousel and `hidden` will automatically mute when the browser/tab becomes hidden. Use an empty list (`[]`) to never automatically mute.|
-| `auto_unmute` | `[]` | :heavy_multiplication_x: | An array of conditions in which media items are unmuted. `selected` will automatically unmute when a media item is unselected in the carousel and `visible` will automatically unmute when the browser/tab becomes visible. Use an empty list (`[]`) to never automatically unmute. Note that some browsers will not allow automated unmute until the user has interacted with the page in some way -- if the user has not then the browser may pause the media instead.|
+| `auto_play` | `[selected, visible]` | :heavy_multiplication_x: | A list of conditions in which media items are automatically played.`selected` will automatically play when a media item is selected in the carousel and `visible` will automatically play when the browser/tab becomes visible. Use an empty list (`[]`) to never automatically play.|
+| `auto_pause` | `[unselected, hidden]` | :heavy_multiplication_x: | A list of conditions in which media items are automatically paused. `unselected` will automatically pause when a media item is unselected in the carousel and `hidden` will automatically pause when the browser/tab becomes hidden. Use an empty list (`[]`) to never automatically pause.|
+| `auto_mute` | `[unselected, hidden]` | :heavy_multiplication_x: | A list of conditions in which media items are muted. `unselected` will automatically mute when a media item is unselected in the carousel and `hidden` will automatically mute when the browser/tab becomes hidden. Use an empty list (`[]`) to never automatically mute.|
+| `auto_unmute` | `[]` | :heavy_multiplication_x: | A list of conditions in which media items are unmuted. `selected` will automatically unmute when a media item is unselected in the carousel and `visible` will automatically unmute when the browser/tab becomes visible. Use an empty list (`[]`) to never automatically unmute. Note that some browsers will not allow automated unmute until the user has interacted with the page in some way -- if the user has not then the browser may pause the media instead.|
 | `lazy_load` | `true` | :heavy_multiplication_x: | Whether or not to lazily load media in the Media viewer carousel. Setting this will false will fetch all media immediately which may make the carousel experience smoother at a cost of (potentially) a substantial number of simultaneous media fetches on load. |
 | `draggable` | `true` | :heavy_multiplication_x: | Whether or not the Media viewer carousel can be dragged left or right, via touch/swipe and mouse dragging. |
 | `zoomable` | `true` | :heavy_multiplication_x: | Whether or not the Media Viewer can be zoomed and panned, via touch/pinch and mouse scroll wheel with `ctrl` held. |
@@ -1148,7 +1148,7 @@ item, that has both of the following parameters set:
 
 | Option | Default | Overridable | Description |
 | - | - | - | - |
-| `conditions` | | :heavy_multiplication_x: | A set of conditions that must evaluate to `true` in order for the overrides to be applied. See [Frigate Card Conditions](#frigate-card-conditions). |
+| `conditions` | | :heavy_multiplication_x: | A list of conditions that must evaluate to `true` in order for the overrides to be applied. See [Frigate Card Conditions](#frigate-card-conditions). |
 | `overrides` | | :heavy_multiplication_x: |Configuration overrides to be applied. Any configuration parameter described in this documentation as 'Overridable' is supported. |
 
 <a name="automation-options"></a>
@@ -1166,7 +1166,7 @@ automations:
 
 | Option | Default | Overridable | Description |
 | - | - | - | - |
-| `conditions` | | :heavy_multiplication_x: | A set of conditions that will trigger the automation. See [Frigate Card Conditions](#frigate-card-conditions). |
+| `conditions` | | :heavy_multiplication_x: | A list of conditions that must evaluate to `true` in order to trigger the automation. See [Frigate Card Conditions](#frigate-card-conditions). |
 | `actions` | | :heavy_multiplication_x: | An optional list of actions that will be run when the conditions evaluate `true`. Actions can be [stock Home Assistant actions](https://www.home-assistant.io/dashboards/actions/) or [Frigate card actions](#frigate-card-actions).|
 | `actions_not` | | :heavy_multiplication_x: | An optional list of actions that will be run when the conditions evaluate `false`. Actions can be [stock Home Assistant actions](https://www.home-assistant.io/dashboards/actions/) or [Frigate card actions](#frigate-card-actions).|
 
@@ -1286,56 +1286,78 @@ Usage:
 
 ## Frigate Card Conditions
 
-Conditions are used to apply certain configuration depending on runtime evaluations. Conditions may be used in `elements` configuration (as part of a `custom:frigate-card-conditional` element) or the `overrides` configuration (see below for both).
-
-All variables listed are under a `conditions:` section.
-
-| Condition | Description |
-| ------------- | --------------------------------------------- |
-| `view` | A list of [views](#views) in which this condition is satified (e.g. `clips`) |
-| `camera` | A list of camera IDs in which this condition is satisfied. See [camera IDs](#camera-ids).|
-| `fullscreen` | If `true` the condition is satisfied if the card is in fullscreen mode. If `false` the condition is satisfied if the card is **NOT** in fullscreen mode.|
-| `expand` | If `true` the condition is satisfied if the card is in expanded mode (in a dialog/popup). If `false` the condition is satisfied if the card is **NOT** in expanded mode (in a dialog/popup).|
-| `state` | A list of state conditions to compare with Home Assistant state. See below. |
-| `media_loaded` | If `true` the condition is satisfied if there is media load**ED** (not load**ING**) in the card (e.g. a clip, snapshot or live view). This may be used to hide controls during media loading or when a message (not media) is being displayed. Note that if `true` this condition will never be satisfied for views that do not themselves load media directly (e.g. gallery).|
-| `media_query` | Any valid [media query](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries) string. Media queries must start and end with parentheses. This may be used to alter card configuration based on device/media properties (e.g. viewport width, orientation). Please note that `width` and `height` refer to the entire viewport not just the card. See the [media query example](#media-query-example).|
-| `interacted` | If `true` the condition is satisfied if the card has had human interaction within `view.interaction_seconds` elapsed seconds. If `false` the condition is satisfied if the card has **NOT** had human interaction in that time. |
-| `triggered` | A list of camera IDs which, if [triggered](#camera-triggers-configuration), satisfy the condition.|
-| `microphone` | A object to include microphone state as part of the condition evaluation. See below.|
+Conditions are used to apply certain configuration depending on runtime evaluations. Conditions may be used in `elements` configuration (as part of a `custom:frigate-card-conditional` element), or in `overrides` and `automations`.
 
 See the [example below](#frigate-card-conditional-example) for a real-world example of how these conditions can be used.
 
-### State Conditions
+Conditions is a list of conditions objects following the below schema:
 
-```yaml
-- conditions:
-    state:
-      - [entries]
-```
-
-The Frigate Card Condition can compare HA state against fixed string values. This is the same as the Home Assistant [Conditional Element](https://www.home-assistant.io/dashboards/picture-elements/#conditional-element) condition, but can be used outside of a Picture Element context (e.g. card configuration overrides).
-
-If multiple entries are provided, the results are `AND`ed.
+### View Condition
 
 | Parameter | Description |
 | - | - |
-| `entity` | The entity ID to check the state for |
-| `state` | Condition will be met if state is equal to this optional string. |
-| `state_not` | Condition will be met if state is unequal to this optional string. |
+| `condition` | Must be `view`. |
+| `views` | A list of [views](#views) in which this condition is satified (e.g. `clips`). |
 
-See the [Menu override example below](#frigate-card-menu-override-example) for an illustration.
+### Camera Condition
+
+| Parameter | Description |
+| - | - |
+| `condition` | Must be `camera`. |
+| `cameras` | A list of camera IDs in which this condition is satisfied. See [camera IDs](#camera-ids). |
+
+### Fullscreen Condition
+
+| Parameter | Description |
+| - | - |
+| `condition` | Must be `fullscreen`. |
+| `fullscreen` | If `true` the condition is satisfied if the card is in fullscreen mode. If `false` the condition is satisfied if the card is **NOT** in fullscreen mode. |
+
+### Expand Condition
+
+| Parameter | Description |
+| - | - |
+| `condition` | Must be `expand`. |
+| `fullscreen` | If `true` the condition is satisfied if the card is in expanded mode (in a dialog/popup). If `false` the condition is satisfied if the card is **NOT** in expanded mode (in a dialog/popup). |
+
+### Media Loaded Condition
+
+| Parameter | Description |
+| - | - |
+| `condition` | Must be `media_loaded`. |
+| `media_loaded` | If `true` the condition is satisfied if there is media load**ED** (not load**ING**) in the card (e.g. a clip, snapshot or live view). This may be used to hide controls during media loading or when a message (not media) is being displayed. Note that if `true` this  
+
+### Screen Condition
+
+| Parameter | Description |
+| - | - |
+| `condition` | Must be `screen`. |
+| `media_query` | Any valid [media query](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries) string. Media queries must start and end with parentheses. This may be used to alter card configuration based on device/media properties (e.g. viewport width, orientation). Please note that `width` and `height` refer to the entire viewport not just the card. See the [media query example](#media-query-example). |
+
+### Interaction Condition
+
+| Parameter | Description |
+| - | - |
+| `condition` | Must be `screen`. |
+| `interaction` | If `true` the condition is satisfied if the card has had human interaction within `view.interaction_seconds` elapsed seconds. If `false` the condition is satisfied if the card has **NOT** had human interaction in that time. |
+
+### Triggered Condition
+
+| Parameter | Description |
+| - | - |
+| `condition` | Must be `screen`. |
+| `triggered` | A list of camera IDs which, if [triggered](#camera-triggers-configuration), satisfy the condition. |
 
 ### Microphone Conditions
-
-```yaml
-- conditions:
-    microphone:
-```
 
 | Parameter | Description |
 | - | - |
 | `muted` | Optional: If `true` or `false` the condition is satisfied if the microphone is muted or unmuted respectively. |
 | `connected` | Optional: If `true` or `false` the condition is satisfied if the microphone is connected or disconnected respectively. |
+
+### Stock Home Assistant Conditions
+
+The stock `state`, `numeric_state` and `user` condition from Home Assistant can also be used. See [their documentation](https://www.home-assistant.io/dashboards/conditional/#card-conditions).
 
 <a name="frigate-card-elements"></a>
 
@@ -1430,7 +1452,7 @@ Parameters for the `custom:frigate-card-conditional` element:
 | ------------- | --------------------------------------------- |
 | `type` | Must be `custom:frigate-card-conditional`. |
  `elements` | The elements to render. Can be any supported element, include additional condition or custom elements. |
-| `conditions` | A set of conditions that must evaluate to true in order for the elements to be rendered. See [Frigate Card Conditions](#frigate-card-conditions). |
+| `conditions` | A list of conditions that must evaluate to true in order for the elements to be rendered. See [Frigate Card Conditions](#frigate-card-conditions). |
 
 <a name="frigate-card-actions"></a>
 
@@ -2367,9 +2389,17 @@ elements:
       width: 100px
   - type: conditional
     conditions:
-      - entity: light.office_main_lights
+      - condition: state
+        entity: light.office_main_lights
         state: on
         state_not: off
+      - condition: numeric_state
+        entity: sensor.light_level
+        above: 20
+        below: 100
+      - condition: user
+        users:
+          - 581fca7fdc014b8b894519cc531f9a04
     elements:
     - type: icon
       icon: mdi:dog
@@ -2493,7 +2523,7 @@ elements:
       scene.kitchen_tv_scene:
         icon: mdi:television
         title: TV!
-    # Show a pig icon if the card is in the live view, in fullscreen mode, light.office_main_lights is on and the media has been loaded.
+    # Show a pig icon if a variety of conditions are met.
   - type: custom:frigate-card-conditional
     elements:
       - type: icon
@@ -2503,16 +2533,38 @@ elements:
           left: 300px
           top: 100px
     conditions:
-      view:
-        - live
-      fullscreen: true
-      camera:
-        - camera.front_door
-      state:
-        - entity: light.office_main_lights
-          state: on
-          state_not: off
-      media_loaded: true
+      - condition: view
+        views:
+          - live
+      - condition: fullscreen
+        fullscreen: true
+      - condition: expand
+        expand: true
+      - condition: camera
+        cameras: camera.front_door
+      - condition: media_loaded
+        media_loaded: true
+      - condition: display_mode
+        display_mode: single
+      - condition: triggered
+        triggered:
+          - camera.front_door
+      - condition: interaction
+        interaction: true
+      - condition: microphone
+        muted: true
+        connected: true
+      - condition: state
+        entity: light.office_main_lights
+        state: on
+        state_not: off
+      - condition: numeric_state
+        entity: sensor.light_level
+        above: 20
+        below: 100
+      - condition: user
+        users:
+          - 581fca7fdc014b8b894519cc531f9a04
 ```
 </details>
 
@@ -2685,26 +2737,20 @@ timeline:
 Reference: [Override Options](#overrides-options).
 
 Overrides allow overriding certain (many) configuration parameters when a given
-condition is met. The below is a fully expanded set of those overridable
-parameters. This is really just repeating the above expansions of the relevant
-sections, rather than indicating new or different parameters, i.e. this
-repetition is included for illustrative purposes of what is overridable.
+list of conditions are met. The below is a fully expanded set of those
+overridable parameters. This is really just repeating the above expansions of
+the relevant sections, rather than indicating new or different parameters, i.e.
+this repetition is included for illustrative purposes of what is overridable.
 
 ```yaml
 overrides:
   - conditions:
-      view:
-        - live
-      fullscreen: true
-      camera:
-        - camera.front_door
-      state:
-        - entity: light.office_main_lights
-          state: on
-          state_not: off
+      - condition: view
+        views:
+          - live
     overrides:
       cameras:
-        # As this is an array, we need to carefully ensure we are
+        # As this is a list, we need to carefully ensure we are
         # overridding the correct index. We do this by specifying
         # earlier indicies as being overridden with an empty object
         # (in YAML this is `{}`). In this example, overriddes will
@@ -2940,7 +2986,8 @@ Reference: [Automation Options](#automation-options).
 ```yaml
 automations:
   - conditions:
-      fullscreen: true
+      - condition: fullscreen
+        fullscreen: true
     actions:
       - action: custom:frigate-card-action
         frigate_card_action: live_substream_on
@@ -3111,8 +3158,9 @@ This example only adds the light entity to the menu if a light is on.
 elements:
   - type: conditional
     conditions:
-      - entity: light.kitchen
-        state: 'on'
+      - condition: state
+        entity: light.kitchen
+        state: on
     elements:
       - type: custom:frigate-card-menu-state-icon
         entity: light.kitchen
@@ -3138,8 +3186,9 @@ This example shows a car icon that calls a service but only in the `live` view.
 elements:
   - type: custom:frigate-card-conditional
     conditions:
-      view:
-        - live
+      - condition: view
+        views:
+          - live
     elements:
       - type: icon
         icon: mdi:car
@@ -3254,8 +3303,9 @@ This example shows submenus conditional on the camera selected.
 elements:
   - type: custom:frigate-card-conditional
     conditions:
-      camera:
-        - camera.front_door
+      - condition: camera
+        cameras:
+          - camera.front_door
     elements:
       - type: custom:frigate-card-menu-submenu
         icon: mdi:door
@@ -3267,8 +3317,9 @@ elements:
               action: toggle
   - type: custom:frigate-card-conditional
     conditions:
-      camera:
-        - camera.living_room
+      - condition: camera
+        cameras:
+          - camera.living_room
     elements:
       - type: custom:frigate-card-menu-submenu
         icon: mdi:sofa
@@ -3353,7 +3404,8 @@ view:
       frigate_card_action: fullscreen
 overrides:
   - conditions:
-      fullscreen: true
+      - condition: fullscreen
+        fullscreen: true
     overrides:
       menu:
         style: none
@@ -3374,8 +3426,9 @@ cameras:
 [...]
 overrides:
   - conditions:
-      camera:
-        - camera.office
+      - condition: camera
+        cameras:
+          - camera.office
     overrides:
       live:
         webrtc_card:
@@ -3390,9 +3443,9 @@ overrides:
 ```yaml
 overrides:
   - conditions:
-      state:
-        - entity: light.office_lights
-          state: 'on'
+      - condition: state
+        entity: light.office_lights
+        state: 'on'
     overrides:
       menu:
         position: bottom
@@ -3420,9 +3473,9 @@ view:
     - binary_sensor.alarm_armed
 overrides:
   - conditions:
-      state:
-        - entity: binary_sensor.alarm_armed
-          state: 'off'
+      - condition: state
+        entity: binary_sensor.alarm_armed
+        state: 'off'
     overrides:
       view:
         default: image
@@ -3441,7 +3494,8 @@ menu:
   style: hidden
 overrides:
   - conditions:
-      expand: true
+      - condition: expand
+        expand: true
     overrides:
       menu:
         style: overlay
@@ -3719,8 +3773,9 @@ elements:
           data:
             entity_id: siren.siren
     conditions:
-      triggered:
-        - camera.office
+      - condition: triggered
+        triggered:
+          - camera.office
 ```
 </details>
 
@@ -3766,7 +3821,7 @@ cameras:
 
 <a name="media-query-example"></a>
 
-### Using Media Query conditions
+### Using `screen` / Media Query conditions
 
 Alter the card configuration based on device or viewport properties.
 
@@ -3780,7 +3835,8 @@ cameras:
   - camera_entity: camera.sitting_room
 overrides:
   - conditions:
-      media_query: '(max-width: 300px)'
+      - condition: screen
+        media_query: '(max-width: 300px)'
     overrides:
       menu:
         style: none
@@ -3805,7 +3861,8 @@ menu:
   style: overlay
 overrides:
   - conditions:
-      media_query: '(orientation: landscape)'
+      - condition: screen
+        media_query: '(orientation: landscape)'
     overrides:
       menu:
         position: left
@@ -3985,7 +4042,8 @@ fullscreen mode.
 ```yaml
 automations:
   - conditions:
-      fullscreen: true
+      - condition: fullscreen
+        fullscreen: true
     actions:
       - action: custom:frigate-card-action
         frigate_card_action: live_substream_on
@@ -4007,8 +4065,10 @@ auto-layout behavior will be used outside of fullscreen mode.
 ```yaml
 overrides:
   - conditions:
-      fullscreen: true
-      display_mode: grid
+      - condition: fullscreen
+        fullscreen: true
+      - condition: display_mode
+        display_mode: grid
     overrides:
       live:
         display:
@@ -4095,7 +4155,8 @@ automations:
       - action: custom:frigate-card-action
         frigate_card_action: live_substream_off
     conditions:
-      interaction: true
+      - condition: interaction
+        interaction: true
 ```
 </details>
 

--- a/src/card-controller/automations-manager.ts
+++ b/src/card-controller/automations-manager.ts
@@ -38,7 +38,7 @@ export class AutomationsManager {
     for (const automation of this._automations ?? []) {
       const shouldExecute = this._api
         .getConditionsManager()
-        .evaluateCondition(automation.conditions);
+        .evaluateConditions(automation.conditions);
       const actions = shouldExecute ? automation.actions : automation.actions_not;
       const priorEvaluation = this._priorEvaluations.get(automation);
       this._priorEvaluations.set(automation, shouldExecute);

--- a/src/card-controller/conditions-manager.ts
+++ b/src/card-controller/conditions-manager.ts
@@ -5,12 +5,16 @@ import { copyConfig } from '../config-mgmt';
 import {
   FrigateCardCondition,
   frigateConditionalSchema,
-  MicrophoneConditionState,
   OverrideConfigurationKey,
   RawFrigateCardConfig,
   ViewDisplayMode,
 } from '../config/types';
 import { CardConditionAPI } from './types';
+
+interface MicrophoneConditionState {
+  connected?: boolean;
+  muted?: boolean;
+}
 
 interface ConditionState {
   view?: string;
@@ -26,13 +30,13 @@ interface ConditionState {
   user?: CurrentUser;
 }
 
-export class ConditionEvaluateRequestEvent extends Event {
-  public condition: FrigateCardCondition;
+export class ConditionsEvaluateRequestEvent extends Event {
+  public conditions: FrigateCardCondition[];
   public evaluation?: boolean;
 
-  constructor(condition: FrigateCardCondition, eventInitDict?: EventInit) {
-    super('frigate-card:condition:evaluate', eventInitDict);
-    this.condition = condition;
+  constructor(conditions: FrigateCardCondition[], eventInitDict?: EventInit) {
+    super('frigate-card:conditions:evaluate', eventInitDict);
+    this.conditions = conditions;
   }
 }
 
@@ -42,13 +46,13 @@ export class ConditionEvaluateRequestEvent extends Event {
  */
 export function evaluateConditionViaEvent(
   element: HTMLElement,
-  condition?: FrigateCardCondition,
+  conditions?: FrigateCardCondition[],
 ): boolean {
-  if (!condition) {
+  if (!conditions) {
     return true;
   }
 
-  const evaluateEvent = new ConditionEvaluateRequestEvent(condition, {
+  const evaluateEvent = new ConditionsEvaluateRequestEvent(conditions, {
     bubbles: true,
     composed: true,
   });
@@ -70,7 +74,7 @@ export function evaluateConditionViaEvent(
 }
 
 type RawOverrides = {
-  conditions: FrigateCardCondition;
+  conditions: FrigateCardCondition[];
   overrides: RawFrigateCardConfig;
 }[];
 
@@ -84,7 +88,7 @@ export function getOverriddenConfig(
   let overridden = false;
   if (configOverrides) {
     for (const override of configOverrides) {
-      if (manager.evaluateCondition(override.conditions, stateOverrides)) {
+      if (manager.evaluateConditions(override.conditions, stateOverrides)) {
         merge(output, override.overrides);
         overridden = true;
       }
@@ -156,7 +160,7 @@ export class ConditionsManager {
     const getAllConditions = (): FrigateCardCondition[] => {
       const config = this._api.getConfigManager().getConfig();
       const conditions: FrigateCardCondition[] = [];
-      config?.overrides?.forEach((override) => conditions.push(override.conditions));
+      config?.overrides?.forEach((override) => conditions.push(...override.conditions));
 
       // Element conditions can be arbitrarily nested underneath conditionals and
       // custom elements that this card may not known. Here we recursively parse
@@ -164,7 +168,7 @@ export class ConditionsManager {
       const getElementsConditions = (data: unknown): void => {
         const parseResult = frigateConditionalSchema.safeParse(data);
         if (parseResult.success) {
-          conditions.push(parseResult.data.conditions);
+          conditions.push(...parseResult.data.conditions);
           parseResult.data.elements?.forEach(getElementsConditions);
         } else if (data && typeof data === 'object') {
           Object.keys(data).forEach((key) => getElementsConditions(data[key]));
@@ -175,15 +179,12 @@ export class ConditionsManager {
     };
 
     const conditions = getAllConditions();
-    this._hasHAStateConditions = conditions.some(
-      (condition) =>
-        !!condition.state?.length ||
-        !!condition.numeric_state?.length ||
-        !!condition.users?.length,
+    this._hasHAStateConditions = conditions.some((conditionObj) =>
+      ['state', 'numeric_state', 'user'].includes(conditionObj.condition),
     );
-    conditions.forEach((condition) => {
-      if (condition.media_query) {
-        const mql = window.matchMedia(condition.media_query);
+    conditions.forEach((conditionObj) => {
+      if (conditionObj.condition === 'screen') {
+        const mql = window.matchMedia(conditionObj.media_query);
         mql.addEventListener('change', this._mediaQueryTrigger);
         this._mediaQueries.push(mql);
       }
@@ -210,8 +211,17 @@ export class ConditionsManager {
     return this._epoch;
   }
 
-  public evaluateCondition(
-    condition: Readonly<FrigateCardCondition>,
+  public evaluateConditions(
+    conditions: Readonly<FrigateCardCondition>[],
+    stateOverrides?: Partial<ConditionState>,
+  ): boolean {
+    return conditions.every((conditionObj) =>
+      this._evaluateCondition(conditionObj, stateOverrides),
+    );
+  }
+
+  protected _evaluateCondition(
+    conditionObj: Readonly<FrigateCardCondition>,
     stateOverrides?: Partial<ConditionState>,
   ): boolean {
     const state = {
@@ -219,79 +229,71 @@ export class ConditionsManager {
       ...stateOverrides,
     };
 
-    let result = true;
-    if (condition.view?.length) {
-      result &&= !!state?.view && condition.view.includes(state.view);
-    }
-    if (condition.fullscreen !== undefined) {
-      result &&=
-        state.fullscreen !== undefined && condition.fullscreen === state.fullscreen;
-    }
-    if (condition.expand !== undefined) {
-      result &&= state.expand !== undefined && condition.expand === state.expand;
-    }
-    if (condition.camera?.length) {
-      result &&= !!state.camera && condition.camera.includes(state.camera);
-    }
-    if (condition.state?.length) {
-      for (const stateTest of condition.state) {
-        result &&=
+    switch (conditionObj.condition) {
+      case 'view':
+        return !!state?.view && conditionObj.views.includes(state.view);
+      case 'fullscreen':
+        return (
+          state.fullscreen !== undefined && conditionObj.fullscreen === state.fullscreen
+        );
+      case 'expand':
+        return state.expand !== undefined && conditionObj.expand === state.expand;
+      case 'camera':
+        return !!state.camera && conditionObj.cameras.includes(state.camera);
+      case 'state':
+        return (
           !!state.state &&
-          ((!stateTest.state && !stateTest.state_not) ||
-            (stateTest.entity in state.state &&
-              (!stateTest.state ||
-                (Array.isArray(stateTest.state)
-                  ? stateTest.state.includes(state.state[stateTest.entity].state)
-                  : stateTest.state === state.state[stateTest.entity].state)) &&
-              (!stateTest.state_not ||
-                (Array.isArray(stateTest.state_not)
-                  ? !stateTest.state_not.includes(state.state[stateTest.entity].state)
-                  : stateTest.state_not !== state.state[stateTest.entity].state))));
-      }
-    }
-    if (condition.numeric_state?.length) {
-      for (const stateTest of condition.numeric_state) {
-        result &&=
+          ((!conditionObj.state && !conditionObj.state_not) ||
+            (conditionObj.entity in state.state &&
+              (!conditionObj.state ||
+                (Array.isArray(conditionObj.state)
+                  ? conditionObj.state.includes(state.state[conditionObj.entity].state)
+                  : conditionObj.state === state.state[conditionObj.entity].state)) &&
+              (!conditionObj.state_not ||
+                (Array.isArray(conditionObj.state_not)
+                  ? !conditionObj.state_not.includes(
+                      state.state[conditionObj.entity].state,
+                    )
+                  : conditionObj.state_not !== state.state[conditionObj.entity].state))))
+        );
+      case 'numeric_state':
+        return (
           !!state.state &&
-          stateTest.entity in state.state &&
-          state.state[stateTest.entity].state !== undefined &&
-          (stateTest.above === undefined ||
-            Number(state.state[stateTest.entity].state) > stateTest.above) &&
-          (stateTest.below === undefined ||
-            Number(state.state[stateTest.entity].state) < stateTest.below);
-      }
+          conditionObj.entity in state.state &&
+          state.state[conditionObj.entity].state !== undefined &&
+          (conditionObj.above === undefined ||
+            Number(state.state[conditionObj.entity].state) > conditionObj.above) &&
+          (conditionObj.below === undefined ||
+            Number(state.state[conditionObj.entity].state) < conditionObj.below)
+        );
+      case 'user':
+        return !!state.user && conditionObj.users.includes(state.user.id);
+      case 'media_loaded':
+        return (
+          state.media_loaded !== undefined &&
+          conditionObj.media_loaded === state.media_loaded
+        );
+      case 'screen':
+        return window.matchMedia(conditionObj.media_query).matches;
+      case 'display_mode':
+        return !!state.displayMode && conditionObj.display_mode === state.displayMode;
+      case 'triggered':
+        return conditionObj.triggered.some((triggeredCameraID) =>
+          state.triggered?.has(triggeredCameraID),
+        );
+      case 'interaction':
+        return (
+          state.interaction !== undefined &&
+          conditionObj.interaction === state.interaction
+        );
+      case 'microphone':
+        return (
+          (conditionObj.connected === undefined ||
+            state.microphone?.connected === conditionObj.connected) &&
+          (conditionObj.muted === undefined ||
+            state.microphone?.muted === conditionObj.muted)
+        );
     }
-    if (condition.users?.length) {
-      result &&= !!state.user && condition.users.includes(state.user.id);
-    }
-    if (condition.media_loaded !== undefined) {
-      result &&=
-        state.media_loaded !== undefined &&
-        condition.media_loaded === state.media_loaded;
-    }
-    if (condition.media_query) {
-      result &&= window.matchMedia(condition.media_query).matches;
-    }
-    if (condition.display_mode) {
-      result &&= !!state.displayMode && condition.display_mode === state.displayMode;
-    }
-    if (condition.triggered?.length) {
-      result &&= condition.triggered.some((triggeredCameraID) =>
-        state.triggered?.has(triggeredCameraID),
-      );
-    }
-    if (condition.interaction !== undefined) {
-      result &&=
-        state.interaction !== undefined && condition.interaction === state.interaction;
-    }
-    if (condition.microphone) {
-      result &&=
-        (condition.microphone.connected === undefined ||
-          state.microphone?.connected === condition.microphone.connected) &&
-        (condition.microphone.muted === undefined ||
-          state.microphone?.muted === condition.microphone.muted);
-    }
-    return result;
   }
 
   protected _createEpoch(): ConditionsManagerEpoch {

--- a/src/card-controller/hass-manager.ts
+++ b/src/card-controller/hass-manager.ts
@@ -66,7 +66,10 @@ export class HASSManager {
     }
 
     if (this._api.getConditionsManager().hasHAStateConditions()) {
-      this._api.getConditionsManager().setState({ state: this._hass.states });
+      this._api.getConditionsManager().setState({ 
+        state: this._hass.states,
+        user: this._hass.user,
+      });
     }
 
     // Dark mode may depend on HASS.

--- a/src/card.ts
+++ b/src/card.ts
@@ -8,7 +8,7 @@ import { ViewContext } from 'view';
 import 'web-dialog';
 import pkg from '../package.json';
 import { actionHandler } from './action-handler-directive.js';
-import { ConditionEvaluateRequestEvent } from './card-controller/conditions-manager.js';
+import { ConditionsEvaluateRequestEvent } from './card-controller/conditions-manager.js';
 import { CardController } from './card-controller/controller';
 import { MenuButtonController } from './components-lib/menu-button-controller';
 import './components/elements.js';
@@ -341,10 +341,10 @@ class FrigateCard extends LitElement {
               this._menuButtonController.removeDynamicMenuButton(ev.detail);
               this.requestUpdate();
             }}
-            @frigate-card:condition:evaluate=${(ev: ConditionEvaluateRequestEvent) => {
+            @frigate-card:conditions:evaluate=${(ev: ConditionsEvaluateRequestEvent) => {
               ev.evaluation = this._controller
                 .getConditionsManager()
-                ?.evaluateCondition(ev.condition);
+                ?.evaluateConditions(ev.conditions);
             }}
           >
           </frigate-card-elements>`

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -401,7 +401,7 @@ const imageSchema = elementsBaseSchema.extend({
 });
 
 // https://www.home-assistant.io/dashboards/conditional/#state
-const stateCondition = z.object({
+const stateConditionSchema = z.object({
   condition: z.literal('state'),
   entity: z.string(),
   state: z.string().or(z.string().array()).optional(),
@@ -409,38 +409,36 @@ const stateCondition = z.object({
 });
 
 // https://www.home-assistant.io/dashboards/conditional/#numeric-state
-const numericCondition = z.object({
+const numericStateConditionSchema = z.object({
   condition: z.literal('numeric_state'),
   entity: z.string(),
   above: z.number().optional(),
   below: z.number().optional(),
 });
 
-const mediaQuerySchema = z.string();
-
 // https://www.home-assistant.io/dashboards/conditional/#screen
-const screenCondition = z.object({
+const screenConditionSchema = z.object({
   condition: z.literal('screen'),
-  media_query: mediaQuerySchema,
+  media_query: z.string(),
 });
 
 // https://www.home-assistant.io/dashboards/conditional/#user
-const usersCondition = z.object({
+const usersConditionSchema = z.object({
   condition: z.literal('user'),
   users: z.string().array().min(1),
 });
 
-const stockCondition = z.union([
-  stateCondition,
-  numericCondition,
-  screenCondition,
-  usersCondition,
+const stockConditionSchema = z.discriminatedUnion('condition', [
+  stateConditionSchema,
+  numericStateConditionSchema,
+  screenConditionSchema,
+  usersConditionSchema,
 ]);
 
 // https://www.home-assistant.io/lovelace/picture-elements/#image-element
 export const conditionalSchema = z.object({
   type: z.literal('conditional'),
-  conditions: stockCondition.array(),
+  conditions: stockConditionSchema.array(),
   elements: z.lazy(() => pictureElementsSchema),
 });
 
@@ -516,32 +514,67 @@ export type MenuItem = MenuIcon | MenuStateIcon | MenuSubmenu | MenuSubmenuSelec
 //                  Custom Element Configuration: Conditions
 // *************************************************************************
 
+const viewConditionSchema = z.object({
+  condition: z.literal('view'),
+  views: z.string().array(),
+});
+const fullscreenConditionSchema = z.object({
+  condition: z.literal('fullscreen'),
+  fullscreen: z.boolean(),
+});
+const expandConditionSchema = z.object({
+  condition: z.literal('expand'),
+  expand: z.boolean(),
+});
+const cameraConditionSchema = z.object({
+  condition: z.literal('camera'),
+  cameras: z.string().array(),
+});
+const mediaLoadedConditionSchema = z.object({
+  condition: z.literal('media_loaded'),
+  media_loaded: z.boolean(),
+});
+const displayModeConditionSchema = z.object({
+  condition: z.literal('display_mode'),
+  display_mode: viewDisplayModeSchema,
+});
+const triggeredConditionSchema = z.object({
+  condition: z.literal('triggered'),
+  triggered: z.string().array(),
+});
+const interactionConditionSchema = z.object({
+  condition: z.literal('interaction'),
+  interaction: z.boolean(),
+});
 const microphoneConditionSchema = z.object({
+  condition: z.literal('microphone'),
   connected: z.boolean().optional(),
   muted: z.boolean().optional(),
 });
-export type MicrophoneConditionState = z.infer<typeof microphoneConditionSchema>;
 
-export const frigateCardConditionSchema = z.object({
-  view: z.string().array().optional(),
-  fullscreen: z.boolean().optional(),
-  expand: z.boolean().optional(),
-  camera: z.string().array().optional(),
-  media_loaded: z.boolean().optional(),
-  state: stateCondition.array().optional(),
-  numeric_state: numericCondition.array().optional(),
-  media_query: mediaQuerySchema.optional(),
-  display_mode: viewDisplayModeSchema.optional(),
-  triggered: z.string().array().optional(),
-  interaction: z.boolean().optional(),
-  microphone: microphoneConditionSchema.optional(),
-  users: z.string().array().optional()
-});
+export const frigateCardConditionSchema = z.discriminatedUnion('condition', [
+  // Stock conditions:
+  stateConditionSchema,
+  numericStateConditionSchema,
+  screenConditionSchema,
+  usersConditionSchema,
+
+  // Custom conditions:
+  viewConditionSchema,
+  fullscreenConditionSchema,
+  expandConditionSchema,
+  cameraConditionSchema,
+  mediaLoadedConditionSchema,
+  displayModeConditionSchema,
+  triggeredConditionSchema,
+  interactionConditionSchema,
+  microphoneConditionSchema,
+]);
 export type FrigateCardCondition = z.infer<typeof frigateCardConditionSchema>;
 
 export const frigateConditionalSchema = z.object({
   type: z.literal('custom:frigate-card-conditional'),
-  conditions: frigateCardConditionSchema,
+  conditions: frigateCardConditionSchema.array(),
   elements: z.lazy(() => pictureElementsSchema),
 });
 export type FrigateConditional = z.infer<typeof frigateConditionalSchema>;
@@ -1034,7 +1067,7 @@ export type LiveConfig = z.infer<typeof liveConfigSchema>;
 
 const liveOverridesSchema = z
   .object({
-    conditions: frigateCardConditionSchema,
+    conditions: frigateCardConditionSchema.array(),
     overrides: liveOverridableConfigSchema,
   })
   .array()
@@ -1551,7 +1584,7 @@ export type OverrideConfigurationKey = keyof z.infer<typeof overrideConfiguratio
 
 const overridesSchema = z
   .object({
-    conditions: frigateCardConditionSchema,
+    conditions: frigateCardConditionSchema.array(),
     overrides: overrideConfigurationSchema,
   })
   .array()
@@ -1565,7 +1598,7 @@ const automationActionSchema = actionSchema.array();
 export type AutomationActions = z.infer<typeof automationActionSchema>;
 
 const automationSchema = z.object({
-  conditions: frigateCardConditionSchema,
+  conditions: frigateCardConditionSchema.array(),
   actions: automationActionSchema.optional(),
   actions_not: automationActionSchema.optional(),
 });

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -400,20 +400,47 @@ const imageSchema = elementsBaseSchema.extend({
   aspect_ratio: z.string().optional(),
 });
 
-// This state condition is used both for the Picture elements conditional
-// schema, and also in frigateCardConditionSchema.
-const stateConditions = z
-  .object({
-    entity: z.string(),
-    state: z.string().optional(),
-    state_not: z.string().optional(),
-  })
-  .array();
+// https://www.home-assistant.io/dashboards/conditional/#state
+const stateCondition = z.object({
+  condition: z.literal('state'),
+  entity: z.string(),
+  state: z.string().or(z.string().array()).optional(),
+  state_not: z.string().or(z.string().array()).optional(),
+});
+
+// https://www.home-assistant.io/dashboards/conditional/#numeric-state
+const numericCondition = z.object({
+  condition: z.literal('numeric_state'),
+  entity: z.string(),
+  above: z.number().optional(),
+  below: z.number().optional(),
+});
+
+const mediaQuerySchema = z.string();
+
+// https://www.home-assistant.io/dashboards/conditional/#screen
+const screenCondition = z.object({
+  condition: z.literal('screen'),
+  media_query: mediaQuerySchema,
+});
+
+// https://www.home-assistant.io/dashboards/conditional/#user
+const usersCondition = z.object({
+  condition: z.literal('user'),
+  users: z.string().array().min(1),
+});
+
+const stockCondition = z.union([
+  stateCondition,
+  numericCondition,
+  screenCondition,
+  usersCondition,
+]);
 
 // https://www.home-assistant.io/lovelace/picture-elements/#image-element
 export const conditionalSchema = z.object({
   type: z.literal('conditional'),
-  conditions: stateConditions,
+  conditions: stockCondition.array(),
   elements: z.lazy(() => pictureElementsSchema),
 });
 
@@ -501,12 +528,14 @@ export const frigateCardConditionSchema = z.object({
   expand: z.boolean().optional(),
   camera: z.string().array().optional(),
   media_loaded: z.boolean().optional(),
-  state: stateConditions.optional(),
-  media_query: z.string().optional(),
+  state: stateCondition.array().optional(),
+  numeric_state: numericCondition.array().optional(),
+  media_query: mediaQuerySchema.optional(),
   display_mode: viewDisplayModeSchema.optional(),
   triggered: z.string().array().optional(),
   interaction: z.boolean().optional(),
   microphone: microphoneConditionSchema.optional(),
+  users: z.string().array().optional()
 });
 export type FrigateCardCondition = z.infer<typeof frigateCardConditionSchema>;
 

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,6 +1,8 @@
 export const REPO_URL = 'https://github.com/dermotduffy/frigate-hass-card' as const;
 export const TROUBLESHOOTING_URL = `${REPO_URL}#troubleshooting` as const;
 
+export const CONF_AUTOMATIONS = 'automations' as const;
+
 export const CONF_CAMERAS = 'cameras' as const;
 export const CONF_CAMERAS_ARRAY_CAMERA_ENTITY =
   `${CONF_CAMERAS}.#.camera_entity` as const;

--- a/tests/card-controller/automations-manager.test.ts
+++ b/tests/card-controller/automations-manager.test.ts
@@ -1,8 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AutomationsManager } from '../../src/card-controller/automations-manager.js';
 import { frigateCardHandleAction } from '../../src/utils/action.js';
-import {
-  AutomationsManager,
-} from '../../src/card-controller/automations-manager.js';
 import { createCardAPI, createConfig, createHASS } from '../test-utils.js';
 
 vi.mock('../../src/utils/action.js');
@@ -14,7 +12,7 @@ describe('AutomationsManager', () => {
       frigate_card_action: 'clips',
     },
   ];
-  const conditions = { fullscreen: true };
+  const conditions = [{ condition: 'fullscreen', fullscreen: true }];
 
   afterEach(() => {
     vi.clearAllMocks();
@@ -58,7 +56,7 @@ describe('AutomationsManager', () => {
     automationsManager.execute();
     expect(frigateCardHandleAction).not.toBeCalled();
 
-    vi.mocked(api.getConditionsManager().evaluateCondition).mockReturnValue(true);
+    vi.mocked(api.getConditionsManager().evaluateConditions).mockReturnValue(true);
 
     automationsManager.execute();
     expect(frigateCardHandleAction).toBeCalledTimes(1);
@@ -68,12 +66,12 @@ describe('AutomationsManager', () => {
     automationsManager.execute();
     expect(frigateCardHandleAction).toBeCalledTimes(1);
 
-    vi.mocked(api.getConditionsManager().evaluateCondition).mockReturnValue(false);
+    vi.mocked(api.getConditionsManager().evaluateConditions).mockReturnValue(false);
 
     automationsManager.execute();
     expect(frigateCardHandleAction).toBeCalledTimes(1);
 
-    vi.mocked(api.getConditionsManager().evaluateCondition).mockReturnValue(true);
+    vi.mocked(api.getConditionsManager().evaluateConditions).mockReturnValue(true);
 
     automationsManager.execute();
     expect(frigateCardHandleAction).toBeCalledTimes(2);
@@ -92,7 +90,7 @@ describe('AutomationsManager', () => {
     const api = createCardAPI();
     vi.mocked(api.getHASSManager().getHASS).mockReturnValue(createHASS());
     vi.mocked(api.getConfigManager().getNonOverriddenConfig).mockReturnValue(config);
-    vi.mocked(api.getConditionsManager().evaluateCondition).mockReturnValue(false);
+    vi.mocked(api.getConditionsManager().evaluateConditions).mockReturnValue(false);
 
     const automationsManager = new AutomationsManager(api);
     automationsManager.setAutomationsFromConfig();
@@ -106,11 +104,11 @@ describe('AutomationsManager', () => {
     const config = createConfig({
       automations: [
         {
-          conditions: { fullscreen: true },
+          conditions: [{ condition: 'fullscreen' as const, fullscreen: true }],
           actions: actions,
         },
         {
-          conditions: { fullscreen: true },
+          conditions: [{ condition: 'fullscreen' as const, fullscreen: true }],
           actions_not: actions,
         },
       ],
@@ -127,13 +125,13 @@ describe('AutomationsManager', () => {
     let evaluation = true;
     vi.mocked(frigateCardHandleAction).mockImplementation(() => {
       evaluation = !evaluation;
-      vi.mocked(api.getConditionsManager().evaluateCondition).mockReturnValue(
+      vi.mocked(api.getConditionsManager().evaluateConditions).mockReturnValue(
         evaluation,
       );
       automationsManager.execute();
     });
 
-    vi.mocked(api.getConditionsManager().evaluateCondition).mockReturnValue(evaluation);
+    vi.mocked(api.getConditionsManager().evaluateConditions).mockReturnValue(evaluation);
 
     automationsManager.execute();
 

--- a/tests/card-controller/conditions-manager.test.ts
+++ b/tests/card-controller/conditions-manager.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { FrigateCardCondition } from '../../src/config/types';
 import {
   ConditionEvaluateRequestEvent,
@@ -12,6 +12,7 @@ import {
   createCondition,
   createConfig,
   createStateEntity,
+  createUser,
 } from '../test-utils';
 
 // @vitest-environment jsdom
@@ -145,49 +146,6 @@ describe('getOverridesByKey', () => {
 });
 
 describe('ConditionsManager', () => {
-  const config = {
-    type: 'custom:frigate-card',
-    cameras: [],
-    elements: [
-      {
-        type: 'custom:frigate-card-conditional',
-        conditions: {
-          fullscreen: true,
-        },
-        elements: [
-          {
-            type: 'custom:nested-unknown-object',
-            unknown_key: {
-              type: 'custom:frigate-card-conditional',
-              conditions: {
-                media_query: 'media query goes here',
-              },
-              elements: [],
-            },
-          },
-        ],
-      },
-    ],
-    overrides: [
-      {
-        overrides: {
-          menu: {
-            style: 'overlay',
-          },
-        },
-        conditions: {
-          fullscreen: true,
-          state: [
-            {
-              entity: 'binary_sensor.foo',
-              state: 'on',
-            },
-          ],
-        },
-      },
-    ],
-  };
-
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -214,252 +172,461 @@ describe('ConditionsManager', () => {
     expect(manager.getState()).toEqual(state);
   });
 
-  it('should not return hasHAStateConditions without HA state conditions', () => {
-    const manager = new ConditionsManager(createCardAPI());
-    expect(manager.hasHAStateConditions()).toBeFalsy();
-  });
+  describe('should handle hasHAStateConditions', () => {
+    beforeEach(() => {
+      vi.spyOn(window, 'matchMedia').mockReturnValueOnce({
+        matches: false,
+        addEventListener: vi.fn(),
+      } as unknown as MediaQueryList);
+    });
 
-  it('should return hasHAStateConditions with HA state conditions', () => {
-    vi.spyOn(window, 'matchMedia').mockReturnValueOnce({
-      matches: false,
-      addEventListener: vi.fn(),
-    } as unknown as MediaQueryList);
-    const api = createCardAPI();
-    vi.mocked(api.getConfigManager().getConfig).mockReturnValue(createConfig(config));
-    const manager = new ConditionsManager(api);
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
 
-    manager.setConditionsFromConfig();
-
-    expect(manager.hasHAStateConditions()).toBeTruthy();
-  });
-
-  it('should evaluate conditions with a view', () => {
-    const manager = new ConditionsManager(createCardAPI());
-    const condition = { view: ['foo'] };
-    expect(manager.evaluateCondition(condition)).toBeFalsy();
-    manager.setState({ view: 'foo' });
-    expect(manager.evaluateCondition(condition)).toBeTruthy();
-  });
-
-  it('should evaluate conditions with fullscreen', () => {
-    const manager = new ConditionsManager(createCardAPI());
-    const condition = { fullscreen: true };
-    expect(manager.evaluateCondition(condition)).toBeFalsy();
-    manager.setState({ fullscreen: true });
-    expect(manager.evaluateCondition(condition)).toBeTruthy();
-    manager.setState({ fullscreen: false });
-    expect(manager.evaluateCondition(condition)).toBeFalsy();
-  });
-
-  it('should evaluate conditions with expand', () => {
-    const manager = new ConditionsManager(createCardAPI());
-    const condition = { expand: true };
-    expect(manager.evaluateCondition(condition)).toBeFalsy();
-    manager.setState({ expand: true });
-    expect(manager.evaluateCondition(condition)).toBeTruthy();
-    manager.setState({ expand: false });
-    expect(manager.evaluateCondition(condition)).toBeFalsy();
-  });
-
-  it('should evaluate conditions with camera', () => {
-    const manager = new ConditionsManager(createCardAPI());
-    const condition = { camera: ['bar'] };
-    expect(manager.evaluateCondition(condition)).toBeFalsy();
-    manager.setState({ camera: 'bar' });
-    expect(manager.evaluateCondition(condition)).toBeTruthy();
-    manager.setState({ camera: 'will-not-match' });
-    expect(manager.evaluateCondition(condition)).toBeFalsy();
-  });
-
-  it('should evaluate conditions with ha state positive check', () => {
-    const manager = new ConditionsManager(createCardAPI());
-    const condition = {
-      state: [
-        {
-          entity: 'binary_sensor.foo',
-          state: 'on',
-        },
-      ],
+    const createSuitableConfig = (conditions: FrigateCardCondition) => {
+      return createConfig({
+        overrides: [
+          {
+            overrides: {},
+            conditions: conditions,
+          },
+        ],
+      });
     };
-    expect(manager.evaluateCondition(condition)).toBeFalsy();
-    manager.setState({ state: { 'binary_sensor.foo': createStateEntity() } });
-    expect(manager.evaluateCondition(condition)).toBeTruthy();
-    manager.setState({
-      state: { 'binary_sensor.foo': createStateEntity({ state: 'off' }) },
-    });
-    expect(manager.evaluateCondition(condition)).toBeFalsy();
-  });
 
-  it('should evaluate conditions with ha state negative check', () => {
-    const manager = new ConditionsManager(createCardAPI());
-    const condition = {
-      state: [
-        {
-          entity: 'binary_sensor.foo',
-          state_not: 'on',
-        },
-      ],
-    };
-    expect(manager.evaluateCondition(condition)).toBeFalsy();
-    manager.setState({ state: { 'binary_sensor.foo': createStateEntity() } });
-    expect(manager.evaluateCondition(condition)).toBeFalsy();
-    manager.setState({
-      state: { 'binary_sensor.foo': createStateEntity({ state: 'off' }) },
-    });
-    expect(manager.evaluateCondition(condition)).toBeTruthy();
-  });
-
-  it('should evaluate conditions with media_loaded', () => {
-    const manager = new ConditionsManager(createCardAPI());
-    const condition = { media_loaded: true };
-    expect(manager.evaluateCondition(condition)).toBeFalsy();
-    manager.setState({ media_loaded: true });
-    expect(manager.evaluateCondition(condition)).toBeTruthy();
-    manager.setState({ media_loaded: false });
-    expect(manager.evaluateCondition(condition)).toBeFalsy();
-  });
-
-  it('should evaluate conditions with media query', () => {
-    vi.spyOn(window, 'matchMedia')
-      .mockReturnValueOnce(<MediaQueryList>{ matches: true })
-      .mockReturnValueOnce(<MediaQueryList>{ matches: false });
-
-    const manager = new ConditionsManager(createCardAPI());
-    const condition = { media_query: 'whatever' };
-    expect(manager.evaluateCondition(condition)).toBeTruthy();
-    expect(manager.evaluateCondition(condition)).toBeFalsy();
-  });
-
-  it('should trigger on changes to media query conditions', () => {
-    const addEventListener = vi.fn();
-    const removeEventListener = vi.fn();
-    vi.spyOn(window, 'matchMedia').mockReturnValueOnce({
-      matches: true,
-      addEventListener: addEventListener,
-      removeEventListener: removeEventListener,
-    } as unknown as MediaQueryList);
-    const api = createCardAPI();
-    vi.mocked(api.getConfigManager().getConfig).mockReturnValue(createConfig(config));
-    const callback = vi.fn();
-    const manager = new ConditionsManager(api, callback);
-
-    manager.setConditionsFromConfig();
-
-    expect(addEventListener).toHaveBeenCalledWith('change', expect.anything());
-
-    // Call the media query callback and use it to pretend a match happened. The
-    // callback is the 0th mock innvocation and the 1st argument.
-    addEventListener.mock.calls[0][1]();
-
-    // This should result in a callback to our state listener.
-    expect(callback).toBeCalled();
-
-    // Remove the conditions, which should remove the media query listener.
-    manager.removeConditions();
-    expect(removeEventListener).toBeCalled();
-  });
-
-  it('should evaluate conditions with display mode', () => {
-    const manager = new ConditionsManager(createCardAPI());
-    const condition: FrigateCardCondition = { display_mode: 'grid' };
-    expect(manager.evaluateCondition(condition)).toBeFalsy();
-    manager.setState({ displayMode: 'grid' });
-    expect(manager.evaluateCondition(condition)).toBeTruthy();
-    manager.setState({ displayMode: 'single' });
-    expect(manager.evaluateCondition(condition)).toBeFalsy();
-  });
-
-  it('should evaluate conditions with triggers', () => {
-    const manager = new ConditionsManager(createCardAPI());
-    const condition: FrigateCardCondition = { triggered: ['camera_1', 'camera_2'] };
-    expect(manager.evaluateCondition(condition)).toBeFalsy();
-    manager.setState({ triggered: new Set(['camera_1']) });
-    expect(manager.evaluateCondition(condition)).toBeTruthy();
-    manager.setState({ triggered: new Set(['camera_2', 'camera_1', 'camera_3']) });
-    expect(manager.evaluateCondition(condition)).toBeTruthy();
-    manager.setState({ triggered: new Set(['camera_3']) });
-    expect(manager.evaluateCondition(condition)).toBeFalsy();
-  });
-
-  it('should evaluate conditions with interaction', () => {
-    const manager = new ConditionsManager(createCardAPI());
-    const condition: FrigateCardCondition = { interaction: true };
-    expect(manager.evaluateCondition(condition)).toBeFalsy();
-    manager.setState({ interaction: true });
-    expect(manager.evaluateCondition(condition)).toBeTruthy();
-    manager.setState({ interaction: false });
-    expect(manager.evaluateCondition(condition)).toBeFalsy();
-  });
-
-  describe('should evaluate conditions with microphone', () => {
-    it('empty', () => {
+    it('without HA state conditions', () => {
       const manager = new ConditionsManager(createCardAPI());
-      const condition: FrigateCardCondition = { microphone: {} };
-      expect(manager.evaluateCondition(condition)).toBeTruthy();
-      manager.setState({ microphone: { connected: true } });
-      expect(manager.evaluateCondition(condition)).toBeTruthy();
-      manager.setState({ microphone: { connected: false } });
-      expect(manager.evaluateCondition(condition)).toBeTruthy();
-      manager.setState({ microphone: { muted: true } });
-      expect(manager.evaluateCondition(condition)).toBeTruthy();
-      manager.setState({ microphone: { muted: false } });
+      expect(manager.hasHAStateConditions()).toBeFalsy();
+    });
+
+    it('with HA state conditions', () => {
+      const api = createCardAPI();
+      const numericConfig = createSuitableConfig({
+        state: [
+          {
+            condition: 'state',
+            entity: 'binary_sensor.foo',
+            state: 'on',
+          },
+        ],
+      });
+      vi.mocked(api.getConfigManager().getConfig).mockReturnValue(numericConfig);
+      const manager = new ConditionsManager(api);
+      manager.setConditionsFromConfig();
+
+      expect(manager.hasHAStateConditions()).toBeTruthy();
+    });
+
+    it('with HA numeric_state conditions', () => {
+      const api = createCardAPI();
+      const stateConfig = createSuitableConfig({
+        numeric_state: [
+          {
+            entity: 'sensor.foo',
+            condition: 'numeric_state' as const,
+            above: 10,
+          },
+        ],
+      });
+      vi.mocked(api.getConfigManager().getConfig).mockReturnValue(stateConfig);
+      const manager = new ConditionsManager(api);
+      manager.setConditionsFromConfig();
+
+      expect(manager.hasHAStateConditions()).toBeTruthy();
+    });
+
+    it('with HA user conditions', () => {
+      const api = createCardAPI();
+      const userConfig = createSuitableConfig({
+        users: ['user_1'],
+      });
+      vi.mocked(api.getConfigManager().getConfig).mockReturnValue(userConfig);
+      const manager = new ConditionsManager(api);
+      manager.setConditionsFromConfig();
+
+      expect(manager.hasHAStateConditions()).toBeTruthy();
+    });
+  });
+
+  describe('should evaluate conditions', () => {
+    it('with a view', () => {
+      const manager = new ConditionsManager(createCardAPI());
+      const condition = { view: ['foo'] };
+      expect(manager.evaluateCondition(condition)).toBeFalsy();
+      manager.setState({ view: 'foo' });
       expect(manager.evaluateCondition(condition)).toBeTruthy();
     });
 
-    it('connected is true', () => {
+    it('with fullscreen', () => {
       const manager = new ConditionsManager(createCardAPI());
-      const condition: FrigateCardCondition = { microphone: { connected: true } };
+      const condition = { fullscreen: true };
       expect(manager.evaluateCondition(condition)).toBeFalsy();
-      manager.setState({ microphone: { connected: true } });
+      manager.setState({ fullscreen: true });
       expect(manager.evaluateCondition(condition)).toBeTruthy();
-      manager.setState({ microphone: { connected: false } });
+      manager.setState({ fullscreen: false });
       expect(manager.evaluateCondition(condition)).toBeFalsy();
     });
 
-    it('connected is false', () => {
+    it('with expand', () => {
       const manager = new ConditionsManager(createCardAPI());
-      const condition: FrigateCardCondition = { microphone: { connected: false } };
+      const condition = { expand: true };
       expect(manager.evaluateCondition(condition)).toBeFalsy();
-      manager.setState({ microphone: { connected: true } });
-      expect(manager.evaluateCondition(condition)).toBeFalsy();
-      manager.setState({ microphone: { connected: false } });
+      manager.setState({ expand: true });
       expect(manager.evaluateCondition(condition)).toBeTruthy();
-    });
-
-    it('muted is true', () => {
-      const manager = new ConditionsManager(createCardAPI());
-      const condition: FrigateCardCondition = { microphone: { muted: true } };
-      expect(manager.evaluateCondition(condition)).toBeFalsy();
-      manager.setState({ microphone: { muted: true } });
-      expect(manager.evaluateCondition(condition)).toBeTruthy();
-      manager.setState({ microphone: { muted: false } });
+      manager.setState({ expand: false });
       expect(manager.evaluateCondition(condition)).toBeFalsy();
     });
 
-    it('muted is false', () => {
+    it('camera', () => {
       const manager = new ConditionsManager(createCardAPI());
-      const condition: FrigateCardCondition = { microphone: { muted: false } };
+      const condition = { camera: ['bar'] };
       expect(manager.evaluateCondition(condition)).toBeFalsy();
-      manager.setState({ microphone: { muted: true } });
-      expect(manager.evaluateCondition(condition)).toBeFalsy();
-      manager.setState({ microphone: { muted: false } });
+      manager.setState({ camera: 'bar' });
       expect(manager.evaluateCondition(condition)).toBeTruthy();
+      manager.setState({ camera: 'will-not-match' });
+      expect(manager.evaluateCondition(condition)).toBeFalsy();
     });
 
-    it('connected and muted', () => {
+    describe('with stock HA conditions', () => {
+      describe('state check', () => {
+        describe('positive', () => {
+          it('single', () => {
+            const manager = new ConditionsManager(createCardAPI());
+            const condition = {
+              state: [
+                {
+                  condition: 'state' as const,
+                  entity: 'binary_sensor.foo',
+                  state: 'on',
+                },
+              ],
+            };
+            expect(manager.evaluateCondition(condition)).toBeFalsy();
+            manager.setState({ state: { 'binary_sensor.foo': createStateEntity() } });
+            expect(manager.evaluateCondition(condition)).toBeTruthy();
+            manager.setState({
+              state: { 'binary_sensor.foo': createStateEntity({ state: 'off' }) },
+            });
+            expect(manager.evaluateCondition(condition)).toBeFalsy();
+          });
+
+          it('multiple', () => {
+            const manager = new ConditionsManager(createCardAPI());
+            const condition = {
+              state: [
+                {
+                  condition: 'state' as const,
+                  entity: 'binary_sensor.foo',
+                  state: ['active', 'on'],
+                },
+              ],
+            };
+            expect(manager.evaluateCondition(condition)).toBeFalsy();
+            manager.setState({ state: { 'binary_sensor.foo': createStateEntity() } });
+            expect(manager.evaluateCondition(condition)).toBeTruthy();
+            manager.setState({
+              state: { 'binary_sensor.foo': createStateEntity({ state: 'active' }) },
+            });
+            expect(manager.evaluateCondition(condition)).toBeTruthy();
+            manager.setState({
+              state: { 'binary_sensor.foo': createStateEntity({ state: 'off' }) },
+            });
+            expect(manager.evaluateCondition(condition)).toBeFalsy();
+          });
+        });
+
+        describe('negative', () => {
+          it('single', () => {
+            const manager = new ConditionsManager(createCardAPI());
+            const condition = {
+              state: [
+                {
+                  condition: 'state' as const,
+                  entity: 'binary_sensor.foo',
+                  state_not: 'on',
+                },
+              ],
+            };
+            expect(manager.evaluateCondition(condition)).toBeFalsy();
+            manager.setState({ state: { 'binary_sensor.foo': createStateEntity() } });
+            expect(manager.evaluateCondition(condition)).toBeFalsy();
+            manager.setState({
+              state: { 'binary_sensor.foo': createStateEntity({ state: 'off' }) },
+            });
+            expect(manager.evaluateCondition(condition)).toBeTruthy();
+          });
+        });
+
+        it('multiple', () => {
+          const manager = new ConditionsManager(createCardAPI());
+          const condition = {
+            state: [
+              {
+                condition: 'state' as const,
+                entity: 'binary_sensor.foo',
+                state_not: ['active', 'on'],
+              },
+            ],
+          };
+          expect(manager.evaluateCondition(condition)).toBeFalsy();
+          manager.setState({ state: { 'binary_sensor.foo': createStateEntity() } });
+          expect(manager.evaluateCondition(condition)).toBeFalsy();
+          manager.setState({
+            state: { 'binary_sensor.foo': createStateEntity({ state: 'active' }) },
+          });
+          expect(manager.evaluateCondition(condition)).toBeFalsy();
+          manager.setState({
+            state: { 'binary_sensor.foo': createStateEntity({ state: 'off' }) },
+          });
+          expect(manager.evaluateCondition(condition)).toBeTruthy();
+        });
+      });
+
+      describe('numeric state check', () => {
+        it('above', () => {
+          const manager = new ConditionsManager(createCardAPI());
+          const condition = {
+            numeric_state: [
+              {
+                condition: 'numeric_state' as const,
+                entity: 'sensor.foo',
+                above: 10,
+              },
+            ],
+          };
+          expect(manager.evaluateCondition(condition)).toBeFalsy();
+          manager.setState({
+            state: { 'sensor.foo': createStateEntity({ state: '11' }) },
+          });
+          expect(manager.evaluateCondition(condition)).toBeTruthy();
+          manager.setState({
+            state: { 'binary_sensor.foo': createStateEntity({ state: '9' }) },
+          });
+          expect(manager.evaluateCondition(condition)).toBeFalsy();
+        });
+
+        it('below', () => {
+          const manager = new ConditionsManager(createCardAPI());
+          const condition = {
+            numeric_state: [
+              {
+                condition: 'numeric_state' as const,
+                entity: 'sensor.foo',
+                below: 10,
+              },
+            ],
+          };
+          expect(manager.evaluateCondition(condition)).toBeFalsy();
+          manager.setState({
+            state: { 'sensor.foo': createStateEntity({ state: '11' }) },
+          });
+          expect(manager.evaluateCondition(condition)).toBeFalsy();
+          manager.setState({
+            state: { 'sensor.foo': createStateEntity({ state: '9' }) },
+          });
+          expect(manager.evaluateCondition(condition)).toBeTruthy();
+        });
+      });
+    });
+
+    it('with users', () => {
       const manager = new ConditionsManager(createCardAPI());
-      const condition: FrigateCardCondition = {
-        microphone: { muted: false, connected: true },
+      const condition = {
+        users: ['user_1', 'user_2'],
       };
       expect(manager.evaluateCondition(condition)).toBeFalsy();
-      manager.setState({ microphone: { muted: true } });
-      expect(manager.evaluateCondition(condition)).toBeFalsy();
-      manager.setState({ microphone: { muted: false } });
-      expect(manager.evaluateCondition(condition)).toBeFalsy();
-      manager.setState({ microphone: { connected: false, muted: false } });
-      expect(manager.evaluateCondition(condition)).toBeFalsy();
-      manager.setState({ microphone: { connected: true, muted: false } });
+      manager.setState({
+        user: createUser({ id: 'user_1' }),
+      });
       expect(manager.evaluateCondition(condition)).toBeTruthy();
+      manager.setState({
+        user: createUser({ id: 'user_WRONG' }),
+      });
+      expect(manager.evaluateCondition(condition)).toBeFalsy();
+    });
+
+    it('with media_loaded', () => {
+      const manager = new ConditionsManager(createCardAPI());
+      const condition = { media_loaded: true };
+      expect(manager.evaluateCondition(condition)).toBeFalsy();
+      manager.setState({ media_loaded: true });
+      expect(manager.evaluateCondition(condition)).toBeTruthy();
+      manager.setState({ media_loaded: false });
+      expect(manager.evaluateCondition(condition)).toBeFalsy();
+    });
+
+    describe('with media query', () => {
+      const mediaQueryConfig = {
+        type: 'custom:frigate-card',
+        cameras: [],
+        elements: [
+          {
+            type: 'custom:frigate-card-conditional',
+            conditions: {
+              fullscreen: true,
+            },
+            elements: [
+              {
+                type: 'custom:nested-unknown-object',
+                unknown_key: {
+                  type: 'custom:frigate-card-conditional',
+                  conditions: {
+                    media_query: 'media query goes here',
+                  },
+                  elements: [],
+                },
+              },
+            ],
+          },
+        ],
+      };
+
+      it('on evaluation', () => {
+        vi.spyOn(window, 'matchMedia')
+          .mockReturnValueOnce(<MediaQueryList>{ matches: true })
+          .mockReturnValueOnce(<MediaQueryList>{ matches: false });
+
+        const manager = new ConditionsManager(createCardAPI());
+        const condition = { media_query: 'whatever' };
+        expect(manager.evaluateCondition(condition)).toBeTruthy();
+        expect(manager.evaluateCondition(condition)).toBeFalsy();
+      });
+
+      it('on trigger', () => {
+        const addEventListener = vi.fn();
+        const removeEventListener = vi.fn();
+        vi.spyOn(window, 'matchMedia').mockReturnValueOnce({
+          matches: true,
+          addEventListener: addEventListener,
+          removeEventListener: removeEventListener,
+        } as unknown as MediaQueryList);
+        const api = createCardAPI();
+        vi.mocked(api.getConfigManager().getConfig).mockReturnValue(
+          createConfig(mediaQueryConfig),
+        );
+        const callback = vi.fn();
+        const manager = new ConditionsManager(api, callback);
+
+        manager.setConditionsFromConfig();
+
+        expect(addEventListener).toHaveBeenCalledWith('change', expect.anything());
+
+        // Call the media query callback and use it to pretend a match happened. The
+        // callback is the 0th mock innvocation and the 1st argument.
+        addEventListener.mock.calls[0][1]();
+
+        // This should result in a callback to our state listener.
+        expect(callback).toBeCalled();
+
+        // Remove the conditions, which should remove the media query listener.
+        manager.removeConditions();
+        expect(removeEventListener).toBeCalled();
+      });
+    });
+
+    it('with display mode', () => {
+      const manager = new ConditionsManager(createCardAPI());
+      const condition: FrigateCardCondition = { display_mode: 'grid' };
+      expect(manager.evaluateCondition(condition)).toBeFalsy();
+      manager.setState({ displayMode: 'grid' });
+      expect(manager.evaluateCondition(condition)).toBeTruthy();
+      manager.setState({ displayMode: 'single' });
+      expect(manager.evaluateCondition(condition)).toBeFalsy();
+    });
+
+    it('with triggers', () => {
+      const manager = new ConditionsManager(createCardAPI());
+      const condition: FrigateCardCondition = { triggered: ['camera_1', 'camera_2'] };
+      expect(manager.evaluateCondition(condition)).toBeFalsy();
+      manager.setState({ triggered: new Set(['camera_1']) });
+      expect(manager.evaluateCondition(condition)).toBeTruthy();
+      manager.setState({ triggered: new Set(['camera_2', 'camera_1', 'camera_3']) });
+      expect(manager.evaluateCondition(condition)).toBeTruthy();
+      manager.setState({ triggered: new Set(['camera_3']) });
+      expect(manager.evaluateCondition(condition)).toBeFalsy();
+    });
+
+    it('with interaction', () => {
+      const manager = new ConditionsManager(createCardAPI());
+      const condition: FrigateCardCondition = { interaction: true };
+      expect(manager.evaluateCondition(condition)).toBeFalsy();
+      manager.setState({ interaction: true });
+      expect(manager.evaluateCondition(condition)).toBeTruthy();
+      manager.setState({ interaction: false });
+      expect(manager.evaluateCondition(condition)).toBeFalsy();
+    });
+
+    describe('with microphone', () => {
+      it('empty', () => {
+        const manager = new ConditionsManager(createCardAPI());
+        const condition: FrigateCardCondition = { microphone: {} };
+        expect(manager.evaluateCondition(condition)).toBeTruthy();
+        manager.setState({ microphone: { connected: true } });
+        expect(manager.evaluateCondition(condition)).toBeTruthy();
+        manager.setState({ microphone: { connected: false } });
+        expect(manager.evaluateCondition(condition)).toBeTruthy();
+        manager.setState({ microphone: { muted: true } });
+        expect(manager.evaluateCondition(condition)).toBeTruthy();
+        manager.setState({ microphone: { muted: false } });
+        expect(manager.evaluateCondition(condition)).toBeTruthy();
+      });
+
+      it('connected is true', () => {
+        const manager = new ConditionsManager(createCardAPI());
+        const condition: FrigateCardCondition = { microphone: { connected: true } };
+        expect(manager.evaluateCondition(condition)).toBeFalsy();
+        manager.setState({ microphone: { connected: true } });
+        expect(manager.evaluateCondition(condition)).toBeTruthy();
+        manager.setState({ microphone: { connected: false } });
+        expect(manager.evaluateCondition(condition)).toBeFalsy();
+      });
+
+      it('connected is false', () => {
+        const manager = new ConditionsManager(createCardAPI());
+        const condition: FrigateCardCondition = { microphone: { connected: false } };
+        expect(manager.evaluateCondition(condition)).toBeFalsy();
+        manager.setState({ microphone: { connected: true } });
+        expect(manager.evaluateCondition(condition)).toBeFalsy();
+        manager.setState({ microphone: { connected: false } });
+        expect(manager.evaluateCondition(condition)).toBeTruthy();
+      });
+
+      it('muted is true', () => {
+        const manager = new ConditionsManager(createCardAPI());
+        const condition: FrigateCardCondition = { microphone: { muted: true } };
+        expect(manager.evaluateCondition(condition)).toBeFalsy();
+        manager.setState({ microphone: { muted: true } });
+        expect(manager.evaluateCondition(condition)).toBeTruthy();
+        manager.setState({ microphone: { muted: false } });
+        expect(manager.evaluateCondition(condition)).toBeFalsy();
+      });
+
+      it('muted is false', () => {
+        const manager = new ConditionsManager(createCardAPI());
+        const condition: FrigateCardCondition = { microphone: { muted: false } };
+        expect(manager.evaluateCondition(condition)).toBeFalsy();
+        manager.setState({ microphone: { muted: true } });
+        expect(manager.evaluateCondition(condition)).toBeFalsy();
+        manager.setState({ microphone: { muted: false } });
+        expect(manager.evaluateCondition(condition)).toBeTruthy();
+      });
+
+      it('connected and muted', () => {
+        const manager = new ConditionsManager(createCardAPI());
+        const condition: FrigateCardCondition = {
+          microphone: { muted: false, connected: true },
+        };
+        expect(manager.evaluateCondition(condition)).toBeFalsy();
+        manager.setState({ microphone: { muted: true } });
+        expect(manager.evaluateCondition(condition)).toBeFalsy();
+        manager.setState({ microphone: { muted: false } });
+        expect(manager.evaluateCondition(condition)).toBeFalsy();
+        manager.setState({ microphone: { connected: false, muted: false } });
+        expect(manager.evaluateCondition(condition)).toBeFalsy();
+        manager.setState({ microphone: { connected: true, muted: false } });
+        expect(manager.evaluateCondition(condition)).toBeTruthy();
+      });
     });
   });
 });

--- a/tests/card-controller/hass-manager.test.ts
+++ b/tests/card-controller/hass-manager.test.ts
@@ -9,6 +9,7 @@ import {
   createHASS,
   createStateEntity,
   createStore,
+  createUser,
   createView,
 } from '../test-utils';
 
@@ -44,13 +45,15 @@ describe('HASSManager', () => {
       vi.mocked(api.getConditionsManager().hasHAStateConditions).mockReturnValue(true);
 
       const states = { 'switch.foo': createStateEntity() };
-      const hass = createHASS(states);
+      const user = createUser({ id: 'user_1' });
+      const hass = createHASS(states, user);
 
       manager.setHASS(hass);
 
       expect(api.getConditionsManager().setState).toBeCalledWith(
         expect.objectContaining({
           state: states,
+          user: user,
         }),
       );
     });

--- a/tests/config-mgmt.test.ts
+++ b/tests/config-mgmt.test.ts
@@ -377,9 +377,12 @@ describe('should handle version specific upgrades', () => {
           cameras: [{ camera_entity: 'camera.office' }],
           elements: [
             {
-              conditions: {
-                media_loaded: true,
-              },
+              conditions: [
+                {
+                  condition: 'media_loaded' as const,
+                  media_loaded: true,
+                },
+              ],
             },
             {
               conditions: 'not an object',
@@ -411,9 +414,12 @@ describe('should handle version specific upgrades', () => {
           cameras: [{ camera_entity: 'camera.office' }],
           overrides: [
             {
-              conditions: {
-                media_loaded: true,
-              },
+              conditions: [
+                {
+                  condition: 'media_loaded' as const,
+                  media_loaded: true,
+                },
+              ],
               overrides: {
                 view: {
                   default: 'clips',
@@ -1020,10 +1026,16 @@ describe('should handle version specific upgrades', () => {
           elements: [
             {
               type: 'custom:frigate-card-conditional',
-              conditions: {
-                fullscreen: true,
-                media_loaded: true,
-              },
+              conditions: [
+                {
+                  condition: 'fullscreen' as const,
+                  fullscreen: true,
+                },
+                {
+                  condition: 'media_loaded' as const,
+                  media_loaded: true,
+                },
+              ],
               elements: [
                 {
                   type: 'service-button',
@@ -1790,6 +1802,638 @@ describe('should handle version specific upgrades', () => {
             });
           },
         );
+      });
+    });
+  });
+
+  describe('from condition object to condition array', () => {
+    describe('with view condition', () => {
+      it('elements', () => {
+        const config = {
+          type: 'custom:frigate-card',
+          cameras: [{ camera_entity: 'camera.office' }],
+          elements: [
+            {
+              conditions: {
+                view: ['clips', 'snapshots'],
+              },
+            },
+            {
+              conditions: 'not an object',
+            },
+          ],
+        };
+        expect(upgradeConfig(config)).toBeTruthy();
+        expect(config).toEqual({
+          type: 'custom:frigate-card',
+          cameras: [{ camera_entity: 'camera.office' }],
+          elements: [
+            {
+              conditions: [
+                {
+                  condition: 'view' as const,
+                  views: ['clips', 'snapshots'],
+                },
+              ],
+            },
+            {
+              conditions: 'not an object',
+            },
+          ],
+        });
+      });
+
+      it('overrides', () => {
+        const config = {
+          type: 'custom:frigate-card',
+          cameras: [{ camera_entity: 'camera.office' }],
+          overrides: [
+            {
+              conditions: {
+                view: ['clips', 'snapshots'],
+              },
+              overrides: {
+                view: {
+                  default: 'clips',
+                },
+              },
+            },
+          ],
+        };
+
+        expect(upgradeConfig(config)).toBeTruthy();
+        expect(config).toEqual({
+          type: 'custom:frigate-card',
+          cameras: [{ camera_entity: 'camera.office' }],
+          overrides: [
+            {
+              conditions: [
+                {
+                  condition: 'view' as const,
+                  views: ['clips', 'snapshots'],
+                },
+              ],
+              overrides: {
+                view: {
+                  default: 'clips',
+                },
+              },
+            },
+          ],
+        });
+      });
+
+      it('automations', () => {
+        const config = {
+          type: 'custom:frigate-card',
+          cameras: [{ camera_entity: 'camera.office' }],
+          automations: [
+            {
+              conditions: {
+                view: ['clips', 'snapshots'],
+              },
+              actions: {
+                action: 'custom:frigate-card-action' as const,
+                frigate_card_action: 'live_substream_on' as const,
+              },
+            },
+          ],
+        };
+
+        expect(upgradeConfig(config)).toBeTruthy();
+        expect(config).toEqual({
+          type: 'custom:frigate-card',
+          cameras: [{ camera_entity: 'camera.office' }],
+          automations: [
+            {
+              conditions: [
+                {
+                  condition: 'view' as const,
+                  views: ['clips', 'snapshots'],
+                },
+              ],
+              actions: {
+                action: 'custom:frigate-card-action' as const,
+                frigate_card_action: 'live_substream_on' as const,
+              },
+            },
+          ],
+        });
+      });
+    });
+
+    describe('with camera condition', () => {
+      it('elements', () => {
+        const config = {
+          type: 'custom:frigate-card',
+          cameras: [{ camera_entity: 'camera.office' }],
+          elements: [
+            {
+              conditions: {
+                camera: ['camera_1', 'camera_2'],
+              },
+            },
+            {
+              conditions: 'not an object',
+            },
+          ],
+        };
+        expect(upgradeConfig(config)).toBeTruthy();
+        expect(config).toEqual({
+          type: 'custom:frigate-card',
+          cameras: [{ camera_entity: 'camera.office' }],
+          elements: [
+            {
+              conditions: [
+                {
+                  condition: 'camera' as const,
+                  cameras: ['camera_1', 'camera_2'],
+                },
+              ],
+            },
+            {
+              conditions: 'not an object',
+            },
+          ],
+        });
+      });
+
+      it('overrides', () => {
+        const config = {
+          type: 'custom:frigate-card',
+          cameras: [{ camera_entity: 'camera.office' }],
+          overrides: [
+            {
+              conditions: {
+                camera: ['camera_1', 'camera_2'],
+              },
+              overrides: {
+                view: {
+                  default: 'clips',
+                },
+              },
+            },
+          ],
+        };
+
+        expect(upgradeConfig(config)).toBeTruthy();
+        expect(config).toEqual({
+          type: 'custom:frigate-card',
+          cameras: [{ camera_entity: 'camera.office' }],
+          overrides: [
+            {
+              conditions: [
+                {
+                  condition: 'camera' as const,
+                  cameras: ['camera_1', 'camera_2'],
+                },
+              ],
+              overrides: {
+                view: {
+                  default: 'clips',
+                },
+              },
+            },
+          ],
+        });
+      });
+
+      it('automations', () => {
+        const config = {
+          type: 'custom:frigate-card',
+          cameras: [{ camera_entity: 'camera.office' }],
+          automations: [
+            {
+              conditions: {
+                camera: ['camera_1', 'camera_2'],
+              },
+              actions: {
+                action: 'custom:frigate-card-action' as const,
+                frigate_card_action: 'live_substream_on' as const,
+              },
+            },
+          ],
+        };
+
+        expect(upgradeConfig(config)).toBeTruthy();
+        expect(config).toEqual({
+          type: 'custom:frigate-card',
+          cameras: [{ camera_entity: 'camera.office' }],
+          automations: [
+            {
+              conditions: [
+                {
+                  condition: 'camera' as const,
+                  cameras: ['camera_1', 'camera_2'],
+                },
+              ],
+              actions: {
+                action: 'custom:frigate-card-action' as const,
+                frigate_card_action: 'live_substream_on' as const,
+              },
+            },
+          ],
+        });
+      });
+    });
+
+    describe('with boolean conditions', () => {
+      describe.each([
+        ['fullscreen' as const],
+        ['expand' as const],
+        ['media_loaded' as const],
+      ])('%s', (condition: string) => {
+        it('elements', () => {
+          const config = {
+            type: 'custom:frigate-card',
+            cameras: [{ camera_entity: 'camera.office' }],
+            elements: [
+              {
+                conditions: {
+                  [condition]: true,
+                },
+              },
+              {
+                conditions: 'not an object',
+              },
+            ],
+          };
+          expect(upgradeConfig(config)).toBeTruthy();
+          expect(config).toEqual({
+            type: 'custom:frigate-card',
+            cameras: [{ camera_entity: 'camera.office' }],
+            elements: [
+              {
+                conditions: [
+                  {
+                    condition: condition,
+                    [condition]: true,
+                  },
+                ],
+              },
+              {
+                conditions: 'not an object',
+              },
+            ],
+          });
+        });
+
+        it('overrides', () => {
+          const config = {
+            type: 'custom:frigate-card',
+            cameras: [{ camera_entity: 'camera.office' }],
+            overrides: [
+              {
+                conditions: {
+                  [condition]: true,
+                },
+                overrides: {
+                  view: {
+                    default: 'clips',
+                  },
+                },
+              },
+            ],
+          };
+
+          expect(upgradeConfig(config)).toBeTruthy();
+          expect(config).toEqual({
+            type: 'custom:frigate-card',
+            cameras: [{ camera_entity: 'camera.office' }],
+            overrides: [
+              {
+                conditions: [
+                  {
+                    condition: condition,
+                    [condition]: true,
+                  },
+                ],
+                overrides: {
+                  view: {
+                    default: 'clips',
+                  },
+                },
+              },
+            ],
+          });
+        });
+
+        it('automations', () => {
+          const config = {
+            type: 'custom:frigate-card',
+            cameras: [{ camera_entity: 'camera.office' }],
+            automations: [
+              {
+                conditions: {
+                  [condition]: true,
+                },
+                actions: {
+                  action: 'custom:frigate-card-action' as const,
+                  frigate_card_action: 'live_substream_on' as const,
+                },
+              },
+            ],
+          };
+
+          expect(upgradeConfig(config)).toBeTruthy();
+          expect(config).toEqual({
+            type: 'custom:frigate-card',
+            cameras: [{ camera_entity: 'camera.office' }],
+            automations: [
+              {
+                conditions: [
+                  {
+                    condition: condition,
+                    [condition]: true,
+                  },
+                ],
+                actions: {
+                  action: 'custom:frigate-card-action' as const,
+                  frigate_card_action: 'live_substream_on' as const,
+                },
+              },
+            ],
+          });
+        });
+      });
+    });
+
+    describe('with state condition', () => {
+      it('elements', () => {
+        const config = {
+          type: 'custom:frigate-card',
+          cameras: [{ camera_entity: 'camera.office' }],
+          elements: [
+            {
+              conditions: {
+                state: [
+                  {
+                    entity: 'binary_sensor.first',
+                    state: 'on',
+                  },
+                  {
+                    entity: 'binary_sensor.second',
+                    state_not: 'off',
+                  },
+                  {},
+                ],
+              },
+            },
+            {
+              conditions: 'not an object',
+            },
+          ],
+        };
+        expect(upgradeConfig(config)).toBeTruthy();
+        expect(config).toEqual({
+          type: 'custom:frigate-card',
+          cameras: [{ camera_entity: 'camera.office' }],
+          elements: [
+            {
+              conditions: [
+                {
+                  condition: 'state' as const,
+                  entity: 'binary_sensor.first',
+                  state: 'on',
+                },
+                {
+                  condition: 'state' as const,
+                  entity: 'binary_sensor.second',
+                  state_not: 'off',
+                },
+              ],
+            },
+            {
+              conditions: 'not an object',
+            },
+          ],
+        });
+      });
+
+      it('overrides', () => {
+        const config = {
+          type: 'custom:frigate-card',
+          cameras: [{ camera_entity: 'camera.office' }],
+          overrides: [
+            {
+              conditions: {
+                state: [
+                  {
+                    entity: 'binary_sensor.first',
+                    state: 'on',
+                  },
+                  {
+                    entity: 'binary_sensor.second',
+                    state_not: 'off',
+                  },
+                  {},
+                ],
+              },
+              overrides: {
+                view: {
+                  default: 'clips',
+                },
+              },
+            },
+          ],
+        };
+
+        expect(upgradeConfig(config)).toBeTruthy();
+        expect(config).toEqual({
+          type: 'custom:frigate-card',
+          cameras: [{ camera_entity: 'camera.office' }],
+          overrides: [
+            {
+              conditions: [
+                {
+                  condition: 'state' as const,
+                  entity: 'binary_sensor.first',
+                  state: 'on',
+                },
+                {
+                  condition: 'state' as const,
+                  entity: 'binary_sensor.second',
+                  state_not: 'off',
+                },
+              ],
+              overrides: {
+                view: {
+                  default: 'clips',
+                },
+              },
+            },
+          ],
+        });
+      });
+
+      it('automations', () => {
+        const config = {
+          type: 'custom:frigate-card',
+          cameras: [{ camera_entity: 'camera.office' }],
+          automations: [
+            {
+              conditions: {
+                state: [
+                  {
+                    entity: 'binary_sensor.first',
+                    state: 'on',
+                  },
+                  {
+                    entity: 'binary_sensor.second',
+                    state_not: 'off',
+                  },
+                  {},
+                ],
+              },
+
+              actions: {
+                action: 'custom:frigate-card-action' as const,
+                frigate_card_action: 'live_substream_on' as const,
+              },
+            },
+          ],
+        };
+
+        expect(upgradeConfig(config)).toBeTruthy();
+        expect(config).toEqual({
+          type: 'custom:frigate-card',
+          cameras: [{ camera_entity: 'camera.office' }],
+          automations: [
+            {
+              conditions: [
+                {
+                  condition: 'state' as const,
+                  entity: 'binary_sensor.first',
+                  state: 'on',
+                },
+                {
+                  condition: 'state' as const,
+                  entity: 'binary_sensor.second',
+                  state_not: 'off',
+                },
+              ],
+              actions: {
+                action: 'custom:frigate-card-action' as const,
+                frigate_card_action: 'live_substream_on' as const,
+              },
+            },
+          ],
+        });
+      });
+    });
+
+    describe('with media query condition', () => {
+      it('elements', () => {
+        const config = {
+          type: 'custom:frigate-card',
+          cameras: [{ camera_entity: 'camera.office' }],
+          elements: [
+            {
+              conditions: {
+                media_query: 'query',
+              },
+            },
+            {
+              conditions: 'not an object',
+            },
+          ],
+        };
+        expect(upgradeConfig(config)).toBeTruthy();
+        expect(config).toEqual({
+          type: 'custom:frigate-card',
+          cameras: [{ camera_entity: 'camera.office' }],
+          elements: [
+            {
+              conditions: [
+                {
+                  condition: 'screen' as const,
+                  media_query: 'query',
+                },
+              ],
+            },
+            {
+              conditions: 'not an object',
+            },
+          ],
+        });
+      });
+
+      it('overrides', () => {
+        const config = {
+          type: 'custom:frigate-card',
+          cameras: [{ camera_entity: 'camera.office' }],
+          overrides: [
+            {
+              conditions: {
+                media_query: 'query',
+              },
+              overrides: {
+                view: {
+                  default: 'clips',
+                },
+              },
+            },
+          ],
+        };
+
+        expect(upgradeConfig(config)).toBeTruthy();
+        expect(config).toEqual({
+          type: 'custom:frigate-card',
+          cameras: [{ camera_entity: 'camera.office' }],
+          overrides: [
+            {
+              conditions: [
+                {
+                  condition: 'screen' as const,
+                  media_query: 'query',
+                },
+              ],
+              overrides: {
+                view: {
+                  default: 'clips',
+                },
+              },
+            },
+          ],
+        });
+      });
+
+      it('automations', () => {
+        const config = {
+          type: 'custom:frigate-card',
+          cameras: [{ camera_entity: 'camera.office' }],
+          automations: [
+            {
+              conditions: {
+                media_query: 'query',
+              },
+              actions: {
+                action: 'custom:frigate-card-action' as const,
+                frigate_card_action: 'live_substream_on' as const,
+              },
+            },
+          ],
+        };
+
+        expect(upgradeConfig(config)).toBeTruthy();
+        expect(config).toEqual({
+          type: 'custom:frigate-card',
+          cameras: [{ camera_entity: 'camera.office' }],
+          automations: [
+            {
+              conditions: [
+                {
+                  condition: 'screen' as const,
+                  media_query: 'query',
+                },
+              ],
+              actions: {
+                action: 'custom:frigate-card-action' as const,
+                frigate_card_action: 'live_substream_on' as const,
+              },
+            },
+          ],
+        });
       });
     });
   });

--- a/tests/config/types.test.ts
+++ b/tests/config/types.test.ts
@@ -381,6 +381,7 @@ describe('should lazy evaluate', () => {
         type: 'conditional',
         conditions: [
           {
+            condition: 'state',
             entity: 'light.office_main_lights',
             state: 'on',
             state_not: 'off',
@@ -401,6 +402,7 @@ describe('should lazy evaluate', () => {
     ).toEqual({
       conditions: [
         {
+          condition: 'state',
           entity: 'light.office_main_lights',
           state: 'on',
           state_not: 'off',

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -80,7 +80,10 @@ export const createCamera = (
   return new Camera(config, engine, { capabilities: capabilities });
 };
 
-export const createHASS = (states?: HassEntities, user?: CurrentUser): ExtendedHomeAssistant => {
+export const createHASS = (
+  states?: HassEntities,
+  user?: CurrentUser,
+): ExtendedHomeAssistant => {
   const hass = mock<ExtendedHomeAssistant>();
   if (states) {
     hass.states = states;

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -1,4 +1,4 @@
-import { HomeAssistant } from '@dermotduffy/custom-card-helpers';
+import { CurrentUser, HomeAssistant } from '@dermotduffy/custom-card-helpers';
 import { HassEntities, HassEntity } from 'home-assistant-js-websocket';
 import { expect, vi } from 'vitest';
 import { mock } from 'vitest-mock-extended';
@@ -80,14 +80,27 @@ export const createCamera = (
   return new Camera(config, engine, { capabilities: capabilities });
 };
 
-export const createHASS = (states?: HassEntities): ExtendedHomeAssistant => {
+export const createHASS = (states?: HassEntities, user?: CurrentUser): ExtendedHomeAssistant => {
   const hass = mock<ExtendedHomeAssistant>();
   if (states) {
     hass.states = states;
   }
+  if (user) {
+    hass.user = user;
+  }
   hass.connection.subscribeMessage = vi.fn();
   return hass;
 };
+
+export const createUser = (user?: Partial<CurrentUser>): CurrentUser => ({
+  id: 'user',
+  is_owner: false,
+  is_admin: false,
+  name: 'User',
+  credentials: [],
+  mfa_modules: [],
+  ...user,
+});
 
 export const createRegistryEntity = (entity?: Partial<Entity>): Entity => {
   return {


### PR DESCRIPTION
* Closes #1305 
* This is a backwards incompatible change (but includes automated conversion support), as all Frigate Card conditions are converted to the same style as stock HA conditions: https://www.home-assistant.io/dashboards/conditional/#card-conditions

Before:

```yaml
conditions:
  fullscreen: true
```

After:

```yaml
conditions:
  - condition: fullscreen
    fullscreen: true
```