### PR TITLE
fix: Fix builtin controls showing up when they should not

### DIFF
--- a/src/components/live/providers/ha.ts
+++ b/src/components/live/providers/ha.ts
@@ -21,7 +21,7 @@ export class FrigateCardLiveHA extends LitElement implements FrigateCardMediaPla
   public cameraConfig?: CameraConfig;
 
   @property({ attribute: true, type: Boolean })
-  public controls = true;
+  public controls = false;
 
   protected _playerRef: Ref<Element & FrigateCardMediaPlayer> = createRef();
 


### PR DESCRIPTION
* Closes #1751 

Editorial: For an `attribute` in `lit`, if it's a `Boolean` and the default is `true` -- then the value will never be anything else, since omitting that attribute will cause the web component to use the default (which is also `true`).