### PR TITLE
fix: Panel mode cards with "Kiosk Mode" should fill the screen

### DIFF
--- a/src/scss/card.scss
+++ b/src/scss/card.scss
@@ -43,7 +43,12 @@ frigate-card-loading {
 }
 :host([panel]:not([casted])) {
   // Card always extends to the full height in panel mode minus the header.
-  height: calc(100vh - var(--header-height));
+  //
+  // If the "Kiosk Mode" (https://github.com/maykar/kiosk-mode) plugin is
+  // installed, the --kiosk-header-height variable will be authoritative
+  // instead.
+  // See: https://github.com/dermotduffy/frigate-hass-card/issues/1762
+  height: calc(100vh - var(--kiosk-header-height, var(--header-height)));
 }
 :host([panel][casted]) {
   // Card always extends to the full height in panel mode when casting (there is


### PR DESCRIPTION
* Closes #1762 