### PR TITLE
fix: Correctly detect configuration for the `webrtc-card` live provider

### DIFF
--- a/src/camera-manager/frigate/engine-frigate.ts
+++ b/src/camera-manager/frigate/engine-frigate.ts
@@ -987,18 +987,6 @@ export class FrigateCameraManagerEngine
       };
     };
 
-    const getWebRTCCard = (): CameraEndpoint | null => {
-      // By default use the frigate camera name which is the default recommended
-      // setup as per:
-      // https://deploy-preview-4055--frigate-docs.netlify.app/guides/configuring_go2rtc/
-      //
-      // The user may override this in their webrtc_card configuration.
-      const endpoint = cameraConfig.frigate.camera_name
-        ? cameraConfig.frigate.camera_name
-        : null;
-      return endpoint ? { endpoint: endpoint } : null;
-    };
-
     const ui = getUIEndpoint();
     const go2rtc = getDefaultGo2RTCEndpoint(cameraConfig, {
       url:
@@ -1010,14 +998,12 @@ export class FrigateCameraManagerEngine
       stream: cameraConfig.go2rtc?.stream ?? cameraConfig.frigate.camera_name,
     });
     const jsmpeg = getJSMPEG();
-    const webrtcCard = getWebRTCCard();
 
     return {
       ...super.getCameraEndpoints(cameraConfig, context),
       ...(ui && { ui: ui }),
       ...(go2rtc && { go2rtc: go2rtc }),
       ...(jsmpeg && { jsmpeg: jsmpeg }),
-      ...(webrtcCard && { webrtcCard: webrtcCard }),
     };
   }
 

--- a/src/camera-manager/generic/engine-generic.ts
+++ b/src/camera-manager/generic/engine-generic.ts
@@ -219,10 +219,19 @@ export class GenericCameraManagerEngine implements CameraManagerEngine {
     cameraConfig: CameraConfig,
     _context?: CameraEndpointsContext,
   ): CameraEndpoints | null {
+    const getWebRTCCard = (): CameraEndpoint | null => {
+      // The user may override this in their webrtc_card configuration.
+      const endpoint = cameraConfig.camera_entity ? cameraConfig.camera_entity : null;
+      return endpoint ? { endpoint: endpoint } : null;
+    };
+
     const go2rtc = getDefaultGo2RTCEndpoint(cameraConfig);
-    return go2rtc
+    const webrtcCard = getWebRTCCard();
+
+    return go2rtc || webrtcCard
       ? {
-          go2rtc: go2rtc,
+          ...(go2rtc && { go2rtc: go2rtc }),
+          ...(webrtcCard && { webrtcCard: webrtcCard }),
         }
       : null;
   }

--- a/src/card.ts
+++ b/src/card.ts
@@ -411,11 +411,11 @@ class FrigateCard extends LitElement {
               : undefined}
             .deviceRegistryManager=${this._controller.getDeviceRegistryManager()}
           ></frigate-card-views>
-          ${
-            // Keep message rendering to last to show messages that may have been
-            // generated during the render.
-            renderMessage(this._controller.getMessageManager().getMessage())
-          }
+          ${this._controller.getMessageManager().hasMessage()
+            ? // Keep message rendering to last to show messages that may have been
+              // generated during the render.
+              renderMessage(this._controller.getMessageManager().getMessage())
+            : ''}
         </div>
         ${this._renderMenuStatusContainer('bottom')}
         ${this._config?.elements

--- a/src/components/live/providers/webrtc-card.ts
+++ b/src/components/live/providers/webrtc-card.ts
@@ -178,9 +178,7 @@ export class FrigateCardLiveWebRTCCard
         ...this.cameraConfig.webrtc_card,
       };
       if (!config.url && !config.entity && this.cameraEndpoints?.webrtcCard) {
-        // This will never need to be signed, it is just used internally by the
-        // card as a stream name lookup.
-        config.url = this.cameraEndpoints.webrtcCard.endpoint;
+        config.entity = this.cameraEndpoints.webrtcCard.endpoint;
       }
       webrtc.setConfig(config);
       webrtc.hass = this.hass;

--- a/tests/camera-manager/frigate/engine-frigate.test.ts
+++ b/tests/camera-manager/frigate/engine-frigate.test.ts
@@ -80,6 +80,7 @@ const createFrigateCameraConfig = (config?: RawFrigateCardConfig): CameraConfig 
     frigate: {
       camera_name: 'camera-1',
     },
+    camera_entity: 'camera.office',
     ...config,
   });
 };
@@ -149,7 +150,7 @@ describe('getCameraEndpoints', () => {
         sign: true,
       },
       webrtcCard: {
-        endpoint: 'camera-1',
+        endpoint: 'camera.office',
       },
     });
   });

--- a/tests/camera-manager/generic/engine-generic.test.ts
+++ b/tests/camera-manager/generic/engine-generic.test.ts
@@ -313,6 +313,20 @@ describe('GenericCameraManagerEngine', () => {
         },
       });
     });
+
+    it('for webrtc-card', () => {
+      expect(
+        createEngine().getCameraEndpoints(
+          createGenericCameraConfig({
+            camera_entity: 'camera.office',
+          }),
+        ),
+      ).toEqual({
+        webrtcCard: {
+          endpoint: 'camera.office',
+        },
+      });
+    });
   });
 
   it('should execute PTZ action', () => {


### PR DESCRIPTION
- Closes #1843

If this breaks something for you, please let me know. As a workaround, you should manually be able to set it back to what it was with something like:

```yaml
cameras:
 - camera_entity: camera.office
   webrtc_card:
      url: <frigate camera name>
```